### PR TITLE
fix: Fix WalletInput component when changing its value programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Bump `@adobe/css-tools` from 4.2.0 to 4.3.1
+-   Re-renders on `WalletInput` component when programmatically changing its value
 
 ## [0.2.12] - 2023-08-23
 


### PR DESCRIPTION
## Description

- On the delegation flow, we programmatically change the value of the WalletInput component by setting the connected address value. By doing this, the resolved values are not set to undefined as done on the `setValue` callback. This causes an indefinite `resolveValues` loop that set back and forth the old and new addresses when the old address has an ENS domain linked.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the latest version.
-   [x] I have tested my code on the test network.
