### PR TITLE
feat: APP-2462 added dao credentials dropdown in dao header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Removed display of dao url and dao ens name from `HeaderDao`, substituted with dropdown component
+-   Introduced required `daoAddress` in `HeaderDao`
+-   Made `daoEnsName` optional in `HeaderDao`
+-   Renamed `copiedOnClick` to `copy` prop on `HeaderDao`, made `copy` accept copy input to be more generic
+-   `shortenDaoUrl` util
+
 ## [0.2.17] - 2023-09-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Removed display of dao url and dao ens name from `HeaderDao`, substituted with dropdown component
 -   Introduced required `daoAddress` in `HeaderDao`
 -   Made `daoEnsName` optional in `HeaderDao`
--   Renamed `copiedOnClick` to `copy` prop on `HeaderDao`, made `copy` accept copy input to be more generic
--   `shortenDaoUrl` util
+-   Renamed `copiedOnClick` to `onCopy` prop on `HeaderDao`, made `onCopy` accept copy input to be more generic
+-   Added `shortenDaoUrl` util
 
 ## [0.2.17] - 2023-09-26
 

--- a/src/components/headers/headerDao.stories.tsx
+++ b/src/components/headers/headerDao.stories.tsx
@@ -12,6 +12,7 @@ const Template: Story<HeaderDaoProps> = (args) => <HeaderDao {...args} />;
 export const Dao = Template.bind({});
 Dao.args = {
     daoName: 'DaoName',
+    daoAddress: '0x999e89E75B3C49D3eF628f804F2c10e9A91F0C57',
     daoEnsName: 'daoName.dao.eth',
     description:
         'We are a community that loves trees and the planet. We track where forestation is increasing (or shrinking), fund people who are growing and protecting trees We are a community that loves trees and the planet. We track where forestation is increasing (or shrinking), fund people who are growing and protecting trees We are a community that loves trees and the planet.',

--- a/src/components/headers/headerDao.tsx
+++ b/src/components/headers/headerDao.tsx
@@ -61,8 +61,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
     favorited = false,
     links = [],
     translation,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    onCopy = () => {},
+    onCopy,
     onFavoriteClick,
 }) => {
     const [showAll, setShowAll] = useState(true);
@@ -103,7 +102,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
         const result = [
             {
                 component: (
-                    <CredentialsDropdownItem key={2} onClick={() => onCopy(daoAddress)}>
+                    <CredentialsDropdownItem key={2} onClick={() => onCopy?.(daoAddress)}>
                         {shortenAddress(daoAddress)}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>
@@ -111,7 +110,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
             },
             {
                 component: (
-                    <CredentialsDropdownItem key={3} isLast onClick={() => onCopy(`https://${daoUrl}`)}>
+                    <CredentialsDropdownItem key={3} isLast onClick={() => onCopy?.(`https://${daoUrl}`)}>
                         {shortenDaoUrl(daoUrl)}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>
@@ -122,7 +121,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
         if (daoEnsName) {
             result.unshift({
                 component: (
-                    <CredentialsDropdownItem key={1} onClick={() => onCopy(daoEnsName)}>
+                    <CredentialsDropdownItem key={1} onClick={() => onCopy?.(daoEnsName)}>
                         {daoEnsName}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>

--- a/src/components/headers/headerDao.tsx
+++ b/src/components/headers/headerDao.tsx
@@ -40,7 +40,7 @@ export type HeaderDaoProps = {
         readMore: string;
         readLess: string;
     };
-    copy?: (input: string) => void;
+    onCopy?: (input: string) => void;
     onFavoriteClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
@@ -62,7 +62,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
     links = [],
     translation,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    copy = () => {},
+    onCopy = () => {},
     onFavoriteClick,
 }) => {
     const [showAll, setShowAll] = useState(true);
@@ -103,7 +103,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
         const result = [
             {
                 component: (
-                    <CredentialsDropdownItem key={2} onClick={() => copy(daoAddress)}>
+                    <CredentialsDropdownItem key={2} onClick={() => onCopy(daoAddress)}>
                         {shortenAddress(daoAddress)}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>
@@ -111,7 +111,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
             },
             {
                 component: (
-                    <CredentialsDropdownItem key={3} isLast onClick={() => copy(`https://${daoUrl}`)}>
+                    <CredentialsDropdownItem key={3} isLast onClick={() => onCopy(`https://${daoUrl}`)}>
                         {shortenDaoUrl(daoUrl)}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>
@@ -122,7 +122,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
         if (daoEnsName) {
             result.unshift({
                 component: (
-                    <CredentialsDropdownItem key={1} onClick={() => copy(daoEnsName)}>
+                    <CredentialsDropdownItem key={1} onClick={() => onCopy(daoEnsName)}>
                         {daoEnsName}
                         <StyledCopyIcon />
                     </CredentialsDropdownItem>
@@ -131,7 +131,7 @@ export const HeaderDao: React.FC<HeaderDaoProps> = ({
         }
 
         return result;
-    }, [copy, daoAddress, daoEnsName, daoUrl]);
+    }, [onCopy, daoAddress, daoEnsName, daoUrl]);
 
     return (
         <Card data-testid="header-dao">

--- a/src/utils/addresses.tsx
+++ b/src/utils/addresses.tsx
@@ -42,3 +42,11 @@ export function shortenENS(input: string | null): string {
     const shortenedName = name.slice(0, 7);
     return `${shortenedName}…eth`;
 }
+
+export function shortenDaoUrl(url: string | null): string {
+    if (!url) {
+        return '';
+    }
+
+    return `${url.substring(0, 17)}…`;
+}


### PR DESCRIPTION
## Description

As a user, I want to be able to access my DAO address name from the dashboard so that I don’t have to go all the way to the deposit flow (currently the fastest way to access the DAO address).

Task: [APP-2462](https://aragonassociation.atlassian.net/browse/APP-2462)

## Type of change
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:
-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the latest version.
-   [x] I have tested my code on the test network.


[APP-2462]: https://aragonassociation.atlassian.net/browse/APP-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ