### PR TITLE
fix: APP-2816 - Update InputSearch component to fix SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update `Spinner` and `Button` components to handle responsive sizes
 -   Update `Icon` and `AvatarIcon` components to handle xl and 2xl responsive sizes
 
+### Fixed
+
+-   Update `InputSearch` component to fix server-side rendering
+
 ## [1.0.6] - 2023-12-13
 
 ### Added

--- a/src/components/input/inputSearch/inputSearch.tsx
+++ b/src/components/input/inputSearch/inputSearch.tsx
@@ -12,9 +12,6 @@ export interface IInputSearchProps extends IInputComponentProps {
     isLoading?: boolean;
 }
 
-// Needed to trigger a native onChange event on clear input click (see https://stackoverflow.com/a/46012210)
-const nativeValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
-
 export const InputSearch: React.FC<IInputSearchProps> = (props) => {
     const { isLoading, ...otherProps } = props;
     const { containerProps, inputProps } = useInputProps(otherProps);
@@ -40,7 +37,9 @@ export const InputSearch: React.FC<IInputSearchProps> = (props) => {
             return;
         }
 
-        nativeValueSetter?.call(inputRef.current, '');
+        // Needed to trigger a native onChange event on clear input click (see https://stackoverflow.com/a/46012210)
+        Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set?.call(inputRef.current, '');
+
         const event = new Event('input', { bubbles: true });
         inputRef.current.dispatchEvent(event);
 


### PR DESCRIPTION
## Description

- Update the `InputSearch` component to fix its usage on SSR frameworks. We should only access the `window` object inside `useEffect` hooks or event callbacks so that the components don't crash when rendered on the server side.

Task: [APP-2816](https://aragonassociation.atlassian.net/browse/APP-2816)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-2816]: https://aragonassociation.atlassian.net/browse/APP-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ