### PR TITLE
feat: APP-2815 - implement `size` property with 'sm' + 'md' for Progress component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+-   Added 'sm' (thinner variant) for `Progress` component
+
 ## [1.0.9] - 2024-01-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-<<<<<<< HEAD
 -   Handle size property on `Progress` component
-=======
 -   Implement `InputTime` component
->>>>>>> 43fd497c6e09883557d7e9909d0933211e20392b
 
 ## [1.0.9] - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+
 -   Added 'sm' (thinner variant) for `Progress` component
 
 ## [1.0.9] - 2024-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
--   Added 'sm' (thinner variant) for `Progress` component
+-   Handle size property on `Progress` component
 
 ## [1.0.9] - 2024-01-23
 

--- a/src/components/progress/index.ts
+++ b/src/components/progress/index.ts
@@ -1,1 +1,2 @@
-export { Progress, type IProgressProps } from './progress';
+export { Progress } from './progress';
+export type { IProgressProps } from './progress.api';

--- a/src/components/progress/progress.api.ts
+++ b/src/components/progress/progress.api.ts
@@ -1,0 +1,13 @@
+import { type HTMLAttributes } from "react";
+
+export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Visual variant.
+   * @default default
+   */
+  variant?: 'default' | 'thick' | 'thin';
+  /**
+   * Current progress to be rendered.
+   */
+  value: number;
+}

--- a/src/components/progress/progress.api.ts
+++ b/src/components/progress/progress.api.ts
@@ -2,10 +2,10 @@ import { type HTMLAttributes } from 'react';
 
 export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
     /**
-     * Visual variant.
+     * Size of progress component.
      * @default md
      */
-    variant?: 'md' | 'sm';
+    size?: 'md' | 'sm';
     /**
      * Current progress to be rendered.
      */

--- a/src/components/progress/progress.api.ts
+++ b/src/components/progress/progress.api.ts
@@ -3,9 +3,9 @@ import { type HTMLAttributes } from "react";
 export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Visual variant.
-   * @default default
+   * @default md
    */
-  variant?: 'default' | 'thick' | 'thin';
+  variant?: 'md' | 'sm' ;
   /**
    * Current progress to be rendered.
    */

--- a/src/components/progress/progress.api.ts
+++ b/src/components/progress/progress.api.ts
@@ -1,13 +1,13 @@
-import { type HTMLAttributes } from "react";
+import { type HTMLAttributes } from 'react';
 
 export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Visual variant.
-   * @default md
-   */
-  variant?: 'md' | 'sm' ;
-  /**
-   * Current progress to be rendered.
-   */
-  value: number;
+    /**
+     * Visual variant.
+     * @default md
+     */
+    variant?: 'md' | 'sm';
+    /**
+     * Current progress to be rendered.
+     */
+    value: number;
 }

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -7,13 +7,10 @@ const meta: Meta<typeof Progress> = {
     component: Progress,
     tags: ['autodocs'],
     args: {
+        value: 50,
         size: 'md',
     },
-    argTypes: {
-        value: {
-            control: false,
-        },
-    },
+
     parameters: {
         design: {
             type: 'figma',
@@ -24,6 +21,14 @@ const meta: Meta<typeof Progress> = {
 
 type Story = StoryObj<typeof Progress>;
 
+/**
+ * Default example of the Progress component.
+ */
+export const Default: Story = {
+    render: (props) => {
+        return <Progress {...props} />;
+    },
+};
 /**
  * Separate functional component for animated progress.
  */

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -7,7 +7,12 @@ const meta: Meta<typeof Progress> = {
     component: Progress,
     tags: ['autodocs'],
     args: {
-        variant: 'md',
+        size: 'md',
+    },
+    argTypes: {
+        value: {
+            control: false,
+        },
     },
     parameters: {
         design: {
@@ -20,57 +25,34 @@ const meta: Meta<typeof Progress> = {
 type Story = StoryObj<typeof Progress>;
 
 /**
- * Default usage example of the Progress component.
- */
-export const MD: Story = {
-    args: {
-        value: 10,
-        variant: 'md',
-    },
-};
-
-/**
- * Thin usage example of the Progress component.
- */
-export const SM: Story = {
-    args: {
-        value: 10,
-        variant: 'sm',
-    },
-};
-
-/**
  * Separate functional component for animated progress.
  */
-const AnimatedProgress: React.FC<IProgressProps> = ({ variant }) => {
-    const [value, setValue] = useState(0);
+const AnimatedProgress: React.FC<IProgressProps> = ({ value, ...otherProps }) => {
+    const [currentValue, setCurrentValue] = useState(0);
 
     useEffect(() => {
         const intervalId = setInterval(() => {
-            setValue((currentValue) => {
-                let newValue = 0;
-
-                if (currentValue !== 100) {
-                    const randomValue = Math.random() * 20;
-                    newValue = Math.min(100, currentValue + randomValue);
+            setCurrentValue((prevValue) => {
+                if (prevValue >= 100) {
+                    return prevValue;
                 }
-
-                return newValue;
+                const increment = Math.random() * 20;
+                return Math.min(prevValue + increment, 100);
             });
         }, 1000);
 
         return () => clearInterval(intervalId);
     }, []);
 
-    return <Progress value={value} variant={variant} />;
+    return <Progress value={currentValue} {...otherProps} />;
 };
 
 /**
  * Animation example of the Progress component with variant control.
  */
 export const Animation: Story = {
-    render: ({ variant, value }: IProgressProps) => {
-        return <AnimatedProgress value={value} variant={variant} />;
+    render: (props) => {
+        return <AnimatedProgress {...props} />;
     },
 };
 

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -6,10 +6,6 @@ const meta: Meta<typeof Progress> = {
     title: 'components/Progress',
     component: Progress,
     tags: ['autodocs'],
-    args: {
-        value: 50,
-        size: 'md',
-    },
     parameters: {
         design: {
             type: 'figma',
@@ -24,6 +20,9 @@ type Story = StoryObj<typeof Progress>;
  * Default example of the Progress component.
  */
 export const Default: Story = {
+    args: {
+        value: 50,
+    },
     render: (props) => {
         return <Progress {...props} />;
     },

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -1,11 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useEffect, useState } from 'react';
-import { Progress } from './progress';
+import { Progress, type IProgressProps } from '.';
 
 const meta: Meta<typeof Progress> = {
     title: 'components/Progress',
     component: Progress,
     tags: ['autodocs'],
+    args: {
+        variant: 'default',
+    },
     parameters: {
         design: {
             type: 'figma',
@@ -22,14 +25,38 @@ type Story = StoryObj<typeof Progress>;
 export const Default: Story = {
     args: {
         value: 10,
+        variant: 'default',
     },
 };
 
-export const Animation = () => {
+/**
+ * Thick usage example of the Progress component.
+ */
+export const Thick: Story = {
+    args: {
+        value: 10,
+        variant: 'thick',
+    },
+};
+
+/**
+ * Thin usage example of the Progress component.
+ */
+export const Thin: Story = {
+    args: {
+        value: 10,
+        variant: 'thin',
+    },
+};
+
+/**
+ * Separate functional component for animated progress.
+ */
+const AnimatedProgress: React.FC<IProgressProps> = ({ variant }) => {
     const [value, setValue] = useState(0);
 
     useEffect(() => {
-        setInterval(() => {
+        const intervalId = setInterval(() => {
             setValue((currentValue) => {
                 let newValue = 0;
 
@@ -41,9 +68,20 @@ export const Animation = () => {
                 return newValue;
             });
         }, 1000);
+
+        return () => clearInterval(intervalId);
     }, []);
 
-    return <Progress value={value} />;
+    return <Progress value={value} variant={variant} />;
+};
+
+/**
+ * Animation example of the Progress component with variant control.
+ */
+export const Animation: Story = {
+    render: ({ variant, value }: IProgressProps) => {
+        return <AnimatedProgress value={value} variant={variant} />;
+    },
 };
 
 export default meta;

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Progress> = {
     component: Progress,
     tags: ['autodocs'],
     args: {
-        variant: 'default',
+        variant: 'md',
     },
     parameters: {
         design: {
@@ -22,30 +22,20 @@ type Story = StoryObj<typeof Progress>;
 /**
  * Default usage example of the Progress component.
  */
-export const Default: Story = {
+export const MD: Story = {
     args: {
         value: 10,
-        variant: 'default',
-    },
-};
-
-/**
- * Thick usage example of the Progress component.
- */
-export const Thick: Story = {
-    args: {
-        value: 10,
-        variant: 'thick',
+        variant: 'md',
     },
 };
 
 /**
  * Thin usage example of the Progress component.
  */
-export const Thin: Story = {
+export const SM: Story = {
     args: {
         value: 10,
-        variant: 'thin',
+        variant: 'sm',
     },
 };
 

--- a/src/components/progress/progress.stories.tsx
+++ b/src/components/progress/progress.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof Progress> = {
         value: 50,
         size: 'md',
     },
-
     parameters: {
         design: {
             type: 'figma',
@@ -53,7 +52,7 @@ const AnimatedProgress: React.FC<IProgressProps> = ({ value, ...otherProps }) =>
 };
 
 /**
- * Animation example of the Progress component with variant control.
+ * Animation example of the Progress component.
  */
 export const Animation: Story = {
     render: (props) => {

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Progress, type IProgressProps } from './progress';
+import { Progress, type IProgressProps } from '.';
 
 describe('<Progress /> component', () => {
     const createTestComponent = (props?: Partial<IProgressProps>) => {
@@ -14,5 +14,19 @@ describe('<Progress /> component', () => {
     it('renders a progress indicator', () => {
         render(createTestComponent());
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    describe('variant tests', () => {
+        it('renders medium variant correctly', () => {
+            render(createTestComponent({ variant: 'md' }));
+            const progressBar = screen.getByRole('progressbar');
+            expect(progressBar).toHaveClass('h-[8px]');
+        });
+
+        it('renders small variant correctly', () => {
+            render(createTestComponent({ variant: 'sm' }));
+            const progressBar = screen.getByRole('progressbar');
+            expect(progressBar).toHaveClass('h-[4px]');
+        });
     });
 });

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -15,18 +15,4 @@ describe('<Progress /> component', () => {
         render(createTestComponent());
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
-
-    describe('variant tests', () => {
-        it('renders medium variant correctly', () => {
-            render(createTestComponent({ variant: 'md' }));
-            const progressBar = screen.getByRole('progressbar');
-            expect(progressBar).toHaveClass('h-[8px]');
-        });
-
-        it('renders small variant correctly', () => {
-            render(createTestComponent({ variant: 'sm' }));
-            const progressBar = screen.getByRole('progressbar');
-            expect(progressBar).toHaveClass('h-[4px]');
-        });
-    });
 });

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -3,13 +3,12 @@ import classNames from 'classnames';
 import { type IProgressProps } from './progress.api';
 
 const variantToClassNames = {
-    default: ['h-[8px]'],
-    thick: ['h-[20px]'],
-    thin: ['h-[4px]'],
+    md: ['h-[8px]'],
+    sm: ['h-[4px]'],
 };
 
 export const Progress: React.FC<IProgressProps> = (props) => {
-    const { value, variant = 'default', className, ...otherProps } = props;
+    const { value, variant = 'md', className, ...otherProps } = props;
 
     const processedValue = Math.min(Math.max(1, value), 100);
 

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -1,28 +1,25 @@
 import * as RadixProgress from '@radix-ui/react-progress';
 import classNames from 'classnames';
-import type { HTMLAttributes } from 'react';
+import { type IProgressProps } from './progress.api';
 
-export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
-    /**
-     * Current progress to be rendered.
-     */
-    value: number;
-}
+const variantToClassNames = {
+    default: ['h-[8px]'],
+    thick: ['h-[20px]'],
+    thin: ['h-[4px]'],
+};
 
 export const Progress: React.FC<IProgressProps> = (props) => {
-    const { value, className, ...otherProps } = props;
+    const { value, variant = 'default', className, ...otherProps } = props;
 
     const processedValue = Math.min(Math.max(1, value), 100);
 
+    const containerClassNames = classNames(
+        'relative w-[320px] overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100',
+        variantToClassNames[variant],
+    );
+
     return (
-        <RadixProgress.Root
-            value={value}
-            className={classNames(
-                'relative h-[20px] w-[320px] overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100 p-1',
-                className,
-            )}
-            {...otherProps}
-        >
+        <RadixProgress.Root value={value} className={classNames(containerClassNames, className)} {...otherProps}>
             <RadixProgress.Indicator
                 className={classNames(
                     'h-full rounded-l-xl bg-primary-400 transition-[border-radius,width] duration-500 ease-in-out',

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -2,23 +2,24 @@ import * as RadixProgress from '@radix-ui/react-progress';
 import classNames from 'classnames';
 import { type IProgressProps } from './progress.api';
 
-const variantToClassNames = {
+const sizeToClassNames = {
     md: ['h-[8px]'],
     sm: ['h-[4px]'],
 };
 
 export const Progress: React.FC<IProgressProps> = (props) => {
-    const { value, variant = 'md', className, ...otherProps } = props;
+    const { value, size = 'md', className, ...otherProps } = props;
 
     const processedValue = Math.min(Math.max(1, value), 100);
 
     const containerClassNames = classNames(
         'relative w-[320px] overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100',
-        variantToClassNames[variant],
+        sizeToClassNames[size],
+        className,
     );
 
     return (
-        <RadixProgress.Root value={value} className={classNames(containerClassNames, className)} {...otherProps}>
+        <RadixProgress.Root value={value} className={containerClassNames} {...otherProps}>
             <RadixProgress.Indicator
                 className={classNames(
                     'h-full rounded-l-xl bg-primary-400 transition-[border-radius,width] duration-500 ease-in-out',

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -13,7 +13,7 @@ export const Progress: React.FC<IProgressProps> = (props) => {
     const processedValue = Math.min(Math.max(1, value), 100);
 
     const containerClassNames = classNames(
-        'relative w-[320px] overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100',
+        'relative w-[320px] overflow-hidden rounded-xl bg-neutral-100',
         sizeToClassNames[size],
         className,
     );


### PR DESCRIPTION
## Description

Implemented size property: specifically 'sm' with subsequent relabeled default as 'md'

-   updated 'md' (prev default at `h-[20p]`) to new visual height of `h-[8px]` per spec
-   removed padding from container per spec

Task: [APP-2815](https://aragonassociation.atlassian.net/browse/APP-2815)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.


[APP-2815]: https://aragonassociation.atlassian.net/browse/APP-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ