### PR TITLE
fix: Properly setup library exports and fix CJS build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   Properly export ESM/CJS library depending on current environment
+-   Properly export ESM/CJS library depending on current environment and fix CJS build
 
 ## [1.0.10] - 2024-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Properly export ESM/CJS library depending on current environment
+
 ## [1.0.10] - 2024-02-05
 
 ### Added

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -52,7 +52,7 @@ library:
 -   Import the Aragon ODS stylesheet bundle in your project entry file (e.g. `src/index.js` or `App.js`):
 
     ```typescript
-    import '@aragon/ods/bundle.css';
+    import '@aragon/ods/build.css';
     ```
 
 # Usage

--- a/package.json
+++ b/package.json
@@ -121,5 +121,13 @@
   "engines": {
     "node": ">=18",
     "npm": "please-use-yarn"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./index.css": "./index.css",
+    "./tailwind.config": "./tailwind.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "classnames": "^2.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-imask": "^7.3.0",
-    "react-merge-refs": "^2.0.0"
+    "react-imask": "^7.3.0"
   },
   "peerDependencies": {
     "@tailwindcss/typography": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -124,10 +124,17 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "import": {
+        "types": "./dist/types/src/index.d.ts",
+        "default": "./dist/index.es.js"
+      },
+      "require": {
+        "types": "./dist/types/src/index.d.ts",
+        "default": "./dist/index.cjs.js"
+      }
     },
     "./index.css": "./index.css",
+    "./build.css": "./build.css",
     "./tailwind.config": "./tailwind.config.js"
   }
 }

--- a/src/components/input/inputDate/inputDate.test.tsx
+++ b/src/components/input/inputDate/inputDate.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
-import * as MergeRefs from 'react-merge-refs';
+import * as Utils from '../../../utils';
 import { IconType } from '../../icon';
 import { InputDate, type IInputDateProps } from './inputDate';
 
 describe('<InputDate /> component', () => {
     const useRefMock = jest.spyOn(React, 'useRef');
-    const mergeRefMock = jest.spyOn(MergeRefs, 'mergeRefs');
+    const mergeRefMock = jest.spyOn(Utils, 'mergeRefs');
 
     afterEach(() => {
         useRefMock.mockReset();

--- a/src/components/input/inputDate/inputDate.tsx
+++ b/src/components/input/inputDate/inputDate.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { forwardRef, useRef } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs } from '../../../utils';
 import { Button } from '../../button';
 import { IconType } from '../../icon';
 import { useInputProps } from '../hooks';

--- a/src/components/input/inputTime/inputTime.test.tsx
+++ b/src/components/input/inputTime/inputTime.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
-import * as MergeRefs from 'react-merge-refs';
+import * as Utils from '../../../utils';
 import { IconType } from '../../icon';
 import { InputTime, type IInputTimeProps } from './inputTime';
 
 describe('<InputTime /> component', () => {
     const useRefMock = jest.spyOn(React, 'useRef');
-    const mergeRefMock = jest.spyOn(MergeRefs, 'mergeRefs');
+    const mergeRefMock = jest.spyOn(Utils, 'mergeRefs');
 
     afterEach(() => {
         useRefMock.mockReset();

--- a/src/components/input/inputTime/inputTime.tsx
+++ b/src/components/input/inputTime/inputTime.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { forwardRef, useRef } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs } from '../../../utils';
 import { Button } from '../../button';
 import { IconType } from '../../icon';
 import { useInputProps } from '../hooks';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './formatterUtils';
+export * from './mergeRefs';
 export * from './responsiveUtils';

--- a/src/utils/mergeRefs/index.ts
+++ b/src/utils/mergeRefs/index.ts
@@ -1,0 +1,1 @@
+export { mergeRefs } from './mergeRefs';

--- a/src/utils/mergeRefs/mergeRefs.test.ts
+++ b/src/utils/mergeRefs/mergeRefs.test.ts
@@ -1,0 +1,19 @@
+import { mergeRefs } from './mergeRefs';
+
+describe('mergeRefs util', () => {
+    it('correctly set value for function refs', () => {
+        const functionRef = jest.fn();
+        const value = 'test';
+        const refSetter = mergeRefs([functionRef]);
+        refSetter(value);
+        expect(functionRef).toHaveBeenCalledWith(value);
+    });
+
+    it('correctly set value for mutable ref object', () => {
+        const mutableRef = { current: null };
+        const value = 'new-value';
+        const refSetter = mergeRefs<string | null>([mutableRef]);
+        refSetter(value);
+        expect(mutableRef.current).toEqual(value);
+    });
+});

--- a/src/utils/mergeRefs/mergeRefs.ts
+++ b/src/utils/mergeRefs/mergeRefs.ts
@@ -1,0 +1,15 @@
+import type { LegacyRef, MutableRefObject, RefCallback } from 'react';
+
+export const mergeRefs = <T = unknown>(
+    refs: Array<MutableRefObject<T> | LegacyRef<T> | undefined | null>,
+): RefCallback<T> => {
+    return (value) => {
+        refs.forEach((ref) => {
+            if (typeof ref === 'function') {
+                ref(value);
+            } else if (ref != null) {
+                (ref as MutableRefObject<T | null>).current = value;
+            }
+        });
+    };
+};

--- a/src/utils/mergeRefs/mergeRefs.ts
+++ b/src/utils/mergeRefs/mergeRefs.ts
@@ -1,5 +1,8 @@
 import type { LegacyRef, MutableRefObject, RefCallback } from 'react';
 
+/**
+ * Utility to merge multiple React refs, inspired by https://github.com/gregberge/react-merge-refs
+ */
 export const mergeRefs = <T = unknown>(
     refs: Array<MutableRefObject<T> | LegacyRef<T> | undefined | null>,
 ): RefCallback<T> => {


### PR DESCRIPTION
## Description

- Fix installation command to use the library without `tailwindcss`
- Add exports to properly use ESM/CJS library depending on the environment 
- Fix CJS build by removing ESM-only library `react-merge-refs`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
