### PR TITLE
feat: APP-2732 - implement inline ADDON element with variants to inputText

### DIFF
--- a/src/components/input/inputContainer/inputContainer.api.ts
+++ b/src/components/input/inputContainer/inputContainer.api.ts
@@ -60,6 +60,10 @@ export interface IInputContainerProps {
      * Classes for the component.
      */
     className?: string;
+    /**
+     * Classes for the input wrapper.
+     */
+    wrapperClassName?: string;
 }
 
 export interface IInputComponentProps

--- a/src/components/input/inputContainer/inputContainer.tsx
+++ b/src/components/input/inputContainer/inputContainer.tsx
@@ -42,6 +42,7 @@ export const InputContainer: React.FC<IInputContainerProps> = (props) => {
         isDisabled,
         children,
         className,
+        wrapperClassName,
         id,
     } = props;
 
@@ -52,6 +53,7 @@ export const InputContainer: React.FC<IInputContainerProps> = (props) => {
         'outline-1 focus-within:outline', // Outline on focus
         'text-base font-normal leading-tight', // Typography
         variantToClassNames[processedVariant],
+        wrapperClassName,
     );
 
     const counterClasses = classNames('text-sm font-normal leading-tight text-neutral-600', {

--- a/src/components/input/inputText/inputText.test.tsx
+++ b/src/components/input/inputText/inputText.test.tsx
@@ -24,4 +24,27 @@ describe('<InputText /> component', () => {
         render(createTestComponent({ inputClassName }));
         expect(screen.getByRole('textbox').className).toContain(inputClassName);
     });
+
+    it('renders with a left addon when addonLeft is provided', () => {
+        const addonLeft = 'Left Addon';
+        render(createTestComponent({ addonLeft }));
+        expect(screen.getByText(addonLeft)).toBeInTheDocument();
+    });
+
+    it('renders with a right addon when addonRight is provided', () => {
+        const addonRight = 'Right Addon';
+        render(createTestComponent({ addonRight }));
+        expect(screen.getByText(addonRight)).toBeInTheDocument();
+    });
+
+    it('does not render both addonLeft and addonRight when both are provided', () => {
+        const addonLeft = 'Left Addon';
+        const addonRight = 'Right Addon';
+        // using unknown as Partial<IInputTextProps> to avoid TS error when forcing both addonLeft and addonRight
+        render(createTestComponent({ addonLeft, addonRight } as unknown as Partial<IInputTextProps>));
+        const leftAddonElement = screen.queryByText(addonLeft);
+        const rightAddonElement = screen.queryByText(addonRight);
+        expect(leftAddonElement).not.toBeInTheDocument();
+        expect(rightAddonElement).not.toBeInTheDocument();
+    });
 });

--- a/src/components/input/inputText/inputText.tsx
+++ b/src/components/input/inputText/inputText.tsx
@@ -1,14 +1,44 @@
+import classNames from 'classnames';
 import { useInputProps } from '../hooks';
-import { InputContainer, type IInputComponentProps } from '../inputContainer';
+import { InputContainer, type IInputComponentProps, type InputVariant } from '../inputContainer';
 
-export interface IInputTextProps extends IInputComponentProps {}
+type BaseProps = Omit<IInputComponentProps, 'addonLeft' | 'addonRight'>;
+type NoAddonProps = BaseProps & { addonLeft?: never; addonRight?: never };
+type LeftAddonProps = BaseProps & { addonLeft: string; addonRight?: never };
+type RightAddonProps = BaseProps & { addonLeft?: never; addonRight: string };
 
-export const InputText: React.FC<IInputTextProps> = (props) => {
-    const { containerProps, inputProps } = useInputProps(props);
+export type IInputTextProps = LeftAddonProps | RightAddonProps | NoAddonProps;
+
+/**
+ * TO-DO: border will look too dark here until we adjust inputContainer.tsx to new design specs for border-{variant}-200
+ * re: QA -- also needs variant specific focus rings on the container
+ **/
+const variantToClassNames: Record<InputVariant | 'disabled', string[]> = {
+    default: ['bg-neutral-100 border-neutral-200 text-neutral-600'],
+    warning: ['bg-warning-100 border-warning-600 text-warning-600'],
+    critical: ['bg-critical-100 border-critical-600 text-critical-600'],
+    disabled: ['bg-neutral-50 border-neutral-200'],
+};
+
+export const InputText: React.FC<IInputTextProps> = ({ children, addonLeft, addonRight, ...otherProps }) => {
+    const { containerProps, inputProps } = useInputProps(otherProps);
+    const variant = otherProps.variant ?? 'default';
+    const processedVariant = otherProps.isDisabled ? 'disabled' : variant;
+
+    const addonClasses = classNames(
+        'flex h-full shrink-0 items-center justify-center px-3 text-base font-normal leading-tight',
+        variantToClassNames[processedVariant],
+        addonLeft && 'border-r-[1px]',
+        addonRight && 'border-l-[1px]',
+    );
 
     return (
-        <InputContainer {...containerProps}>
+        <InputContainer wrapperClassName="overflow-hidden" {...containerProps}>
+            {addonLeft && !addonRight && <div className={addonClasses}>{addonLeft}</div>}
             <input type="text" {...inputProps} />
+            {addonRight && !addonLeft && <div className={addonClasses}>{addonRight}</div>}
         </InputContainer>
     );
 };
+
+InputText.displayName = 'InputText';


### PR DESCRIPTION
## Description

implements a left or right addon inline with the input and matching variant styles from it's parent inputContainer. borrows the addition of wrapperClassName from @RuggeroCino work on APP-2744 for richtext to handle overflow-hidden.


Task: [APP-2732](https://aragonassociation.atlassian.net/browse/APP-2732)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [ ] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.