### PR TITLE
fix: style of InputText component with addon property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
--   Fixed styling conflict in `InputText` introduced by Addon element
 -   Update minor and patch versions of dependencies
 -   Update `husky` to v9
 -   Add `wrapperClassName` property to `InputContainer` component to customise the input wrapper
 -   Update `InputContainer` props to accept any HTML div property and support textarea elements
+
+### Fixed
+
+-   Fix styling conflict in `InputText` introduced by Addon element
 
 ## [1.0.9] - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+-   Fixed styling conflict in `InputText` introduced by Addon element
 -   Update minor and patch versions of dependencies
 -   Update `husky` to v9
 -   Add `wrapperClassName` property to `InputContainer` component to customise the input wrapper

--- a/src/components/input/inputText/inputText.tsx
+++ b/src/components/input/inputText/inputText.tsx
@@ -19,6 +19,7 @@ export const InputText: React.FC<IInputTextProps> = ({ addonPosition = 'left', a
     const variant = otherProps.variant ?? 'default';
     const processedVariant = otherProps.isDisabled ? 'disabled' : variant;
     const showAddon = addon && addon.trim() !== '';
+    const { wrapperClassName: containerWrapperClassName, ...otherContainerProps } = containerProps;
 
     const addonClasses = classNames(
         'flex h-full shrink-0 items-center justify-center px-3 text-base font-normal leading-tight',
@@ -28,7 +29,10 @@ export const InputText: React.FC<IInputTextProps> = ({ addonPosition = 'left', a
     );
 
     return (
-        <InputContainer wrapperClassName="overflow-hidden" {...containerProps}>
+        <InputContainer
+            wrapperClassName={classNames('overflow-hidden', containerWrapperClassName)}
+            {...otherContainerProps}
+        >
             {showAddon && (
                 <div className={addonClasses} data-testid="input-addon">
                     {addon}


### PR DESCRIPTION
## Description

Fixes an issue where props getting generated useInputProps hook was overriding local props in the input wrapper. In this case "overflow-hidden" was not getting applied back in the container.


<!--- Set the correct ticket number -->

Task: No ticket

## Type of change

<!--- Please delete options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.

