### PR TITLE
feat: APP-2878 - Implement Heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
--   Implement `InputFileAvatar` and `Dropdown` components
+-   Implement `Heading`, `InputFileAvatar` and `Dropdown` components
 -   Ref property handling on `Button` component
 
 ## [1.0.13] - 2024-02-14

--- a/src/components/heading/heading.stories.tsx
+++ b/src/components/heading/heading.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heading } from './heading';
+
+const meta: Meta<typeof Heading> = {
+    title: 'components/Heading',
+    component: Heading,
+
+    tags: ['autodocs'],
+    parameters: {
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/ISSDryshtEpB7SUSdNqAcw/branch/jfKRr1V9evJUp1uBeyP3Zz/Aragon-ODS?type=design&node-id=12425%3A9576&mode=design&t=Y5oyqUT7xs50BPvq-1',
+        },
+        docs: {
+            description: {
+                component: 'Component will auto size at `md` breakpoint.',
+            },
+        },
+    },
+};
+
+type Story = StoryObj<typeof Heading>;
+
+/**
+ * Default usage example of the Heading component.
+ */
+export const Default: Story = {
+    render: () => {
+        return (
+            <div className="flex-col space-y-4">
+                <Heading size="h1">Default h1 size</Heading>
+                <Heading size="h2">Default h2 size</Heading>
+                <Heading size="h3">Default h3 size</Heading>
+                <Heading size="h4">Default h4 size</Heading>
+                <Heading size="h5">Default h5 size</Heading>
+            </div>
+        );
+    },
+};
+
+/**
+ * Custom usage example of the Heading component where the <h> tag size is specified by the user.
+ * Inspect to see the semantic element override.
+ */
+export const CustomAs: Story = {
+    render: () => {
+        return (
+            <div className="flex-col space-y-4">
+                <Heading size="h1" as="h5">
+                    Semantic h5 tag as h1 size
+                </Heading>
+                <Heading size="h2" as="h4">
+                    Semantic h4 tag as h2 size
+                </Heading>
+                <Heading size="h3" as="h3">
+                    Semantic h3 tag as h3 size
+                </Heading>
+                <Heading size="h4" as="h2">
+                    Semantic h2 tag as h4 size
+                </Heading>
+                <Heading size="h5" as="h1">
+                    Semantic h1 tag as h5 size
+                </Heading>
+            </div>
+        );
+    },
+};
+export default meta;

--- a/src/components/heading/heading.test.tsx
+++ b/src/components/heading/heading.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { Heading } from './heading';
+
+describe('Heading', () => {
+    const createTestComponent = (props: React.ComponentProps<typeof Heading>) => {
+        const { children, ...otherProps } = props;
+
+        return <Heading {...otherProps}>{children}</Heading>;
+    };
+
+    it('renders without crashing', () => {
+        const size = 'h1';
+        const children = 'Test Heading';
+        render(createTestComponent({ size, children }));
+
+        expect(screen.getByText('Test Heading')).toBeInTheDocument();
+    });
+
+    it('renders the correct element type when `as` prop is provided', () => {
+        const size = 'h1';
+        const as = 'h3';
+        const children = 'Heading as h3';
+        render(createTestComponent({ size, as, children }));
+
+        expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+    });
+});

--- a/src/components/heading/heading.test.tsx
+++ b/src/components/heading/heading.test.tsx
@@ -1,28 +1,27 @@
 import { render, screen } from '@testing-library/react';
-import { Heading } from './heading';
+import { Heading, type IHeadingProps } from './heading';
 
 describe('Heading', () => {
-    const createTestComponent = (props: React.ComponentProps<typeof Heading>) => {
-        const { children, ...otherProps } = props;
+    const createTestComponent = (props?: Partial<IHeadingProps>) => {
+        const completeProps = { ...props };
 
-        return <Heading {...otherProps}>{children}</Heading>;
+        return <Heading {...completeProps} />;
     };
 
     it('renders without crashing', () => {
-        const size = 'h1';
         const children = 'Test Heading';
-        render(createTestComponent({ size, children }));
+        render(createTestComponent({ children }));
 
         expect(screen.getByText('Test Heading')).toBeInTheDocument();
     });
 
     it('renders the correct element type when `as` prop is provided', () => {
-        const size = 'h1';
-        const as = 'h3';
-        const children = 'Heading as h3';
+        const size = 'h2';
+        const as = 'h4';
+        const children = '<h2 /> as <h4 />';
         render(createTestComponent({ size, as, children }));
 
-        expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
-        expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 4 })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
     });
 });

--- a/src/components/heading/heading.test.tsx
+++ b/src/components/heading/heading.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Heading, type IHeadingProps } from './heading';
 
-describe('Heading', () => {
+describe('<Heading /> component', () => {
     const createTestComponent = (props?: Partial<IHeadingProps>) => {
         const completeProps = { ...props };
 

--- a/src/components/heading/heading.tsx
+++ b/src/components/heading/heading.tsx
@@ -27,7 +27,7 @@ const headingToSizeClassNames: Record<HeadingSize, string> = {
 
 export const Heading = forwardRef<HTMLHeadingElement, IHeadingProps>(
     ({ size = 'h1', as, children, className, ...otherProps }, ref) => {
-        const Component = as ?? size;
+        const Tag = as ?? size;
         const headingClassName = classNames(
             'font-normal leading-tight text-neutral-800',
             headingToSizeClassNames[size],
@@ -40,7 +40,7 @@ export const Heading = forwardRef<HTMLHeadingElement, IHeadingProps>(
             ref,
         };
 
-        return React.createElement(Component, headingProps, children);
+        return React.createElement(Tag, headingProps, children);
     },
 );
 

--- a/src/components/heading/heading.tsx
+++ b/src/components/heading/heading.tsx
@@ -1,0 +1,47 @@
+import classNames from 'classnames';
+import React, { forwardRef } from 'react';
+
+export type HeadingSize = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+
+export interface IHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+    /**
+     * Specifies the semantic level of the heading, affecting both the HTML element used (e.g., <h1>, <h2>) and its default styling.
+     * If the 'as' prop is not provided, this value determines the HTML element rendered in the DOM.
+     * @default h1
+     */
+    size: HeadingSize;
+    /**
+     * Optionally overrides the HTML element type that is rendered in the DOM, independent of the heading's semantic level determined by the 'size' prop.
+     * This allows for styling and semantic adjustments where necessary.
+     */
+    as?: HeadingSize;
+}
+
+const headingToSizeClassNames: Record<HeadingSize, string> = {
+    h1: 'text-2xl md:text-3xl',
+    h2: 'text-xl md:text-2xl',
+    h3: 'text-lg md:text-xl',
+    h4: 'text-base md:text-lg',
+    h5: 'text-sm md:text-base',
+};
+
+export const Heading = forwardRef<HTMLHeadingElement, IHeadingProps>(
+    ({ size = 'h1', as, children, className, ...otherProps }, ref) => {
+        const Component = as ?? size;
+        const headingClassName = classNames(
+            'font-normal leading-tight text-neutral-800',
+            headingToSizeClassNames[size],
+            className,
+        );
+
+        const headingProps = {
+            ...otherProps,
+            className: headingClassName,
+            ref,
+        };
+
+        return React.createElement(Component, headingProps, children);
+    },
+);
+
+Heading.displayName = 'Heading';

--- a/src/components/heading/heading.tsx
+++ b/src/components/heading/heading.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 export type HeadingSize = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 
@@ -9,7 +9,7 @@ export interface IHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> 
      * If the 'as' prop is not provided, this value determines the HTML element rendered in the DOM.
      * @default h1
      */
-    size: HeadingSize;
+    size?: HeadingSize;
     /**
      * Optionally overrides the HTML element type that is rendered in the DOM, independent of the heading's semantic level determined by the 'size' prop.
      * This allows for styling and semantic adjustments where necessary.
@@ -25,23 +25,16 @@ const headingToSizeClassNames: Record<HeadingSize, string> = {
     h5: 'text-sm md:text-base',
 };
 
-export const Heading = forwardRef<HTMLHeadingElement, IHeadingProps>(
-    ({ size = 'h1', as, children, className, ...otherProps }, ref) => {
-        const Tag = as ?? size;
-        const headingClassName = classNames(
-            'font-normal leading-tight text-neutral-800',
-            headingToSizeClassNames[size],
-            className,
-        );
+export const Heading = forwardRef<HTMLHeadingElement, IHeadingProps>((props, ref) => {
+    const { size = 'h1', as, className, ...otherProps } = props;
+    const Tag = as ?? size;
+    const headingClassName = classNames(
+        'font-normal leading-tight text-neutral-800',
+        headingToSizeClassNames[size],
+        className,
+    );
 
-        const headingProps = {
-            ...otherProps,
-            className: headingClassName,
-            ref,
-        };
-
-        return React.createElement(Tag, headingProps, children);
-    },
-);
+    return <Tag className={headingClassName} ref={ref} {...otherProps} />;
+});
 
 Heading.displayName = 'Heading';

--- a/src/components/heading/index.tsx
+++ b/src/components/heading/index.tsx
@@ -1,0 +1,1 @@
+export { Heading, type HeadingSize, type IHeadingProps } from './heading';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export * from './button';
 export * from './cards';
 export * from './checkbox';
 export * from './dropdown';
+export * from './heading';
 export * from './icon';
 export * from './illustrations';
 export * from './input';


### PR DESCRIPTION
## Description

Implement <Heading /> component with design sizes for `size` prop (default 'h1') and custom `as` prop for semantic tag override.

Task: [APP-2878](https://aragonassociation.atlassian.net/browse/APP-2878)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the latest version.


[APP-2878]: https://aragonassociation.atlassian.net/browse/APP-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ