### PR TITLE
fix: Fix typos on documentation and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.0.16] - 2024-02-24
+
+### Fixed
+
+-   Typo on `README.md` file
+-   Typo on `src/components/button/button.tsx` file
+-   Typo on `src/utils/formatterUtils/formatterUtilsDefinition.ts` file
+
+
 ## [1.0.15] - 2024-02-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Aragon Open Design System (ODS) is an open source and human-centric design s
 Aragon App. It provides a unified and easy-to-use framework for creating visually consistent and engaging interfaces,
 prioritizing user experience throughout the Aragon ecosystem.
 
-**NOTE**: The Aragon ODS library is currenlty in pre-alpha stage; breaking changes are likely to occur.
+**NOTE**: The Aragon ODS library is currently in pre-alpha stage; breaking changes are likely to occur.
 
 ## Usage
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -45,7 +45,7 @@ const variantToClassNames: Record<ButtonVariant, string[]> = {
         'aria-disabled:bg-warning-100 aria-disabled:text-warning-400 aria-disabled:border-warning-200', // Disabled
     ],
     critical: [
-        'bg-critical-100 text-critical-800 border-critical-300', // Defalt
+        'bg-critical-100 text-critical-800 border-critical-300', // Default
         'hover:border-critical-400 hover:shadow-critical-md', // Hover
         'active:border-critical-500', // Active
         'focus-visible:ring-critical', // Focus

--- a/src/utils/formatterUtils/formatterUtilsDefinitions.ts
+++ b/src/utils/formatterUtils/formatterUtilsDefinitions.ts
@@ -17,7 +17,7 @@ export interface INumberFormat {
      */
     maxSignificantDigits?: DynamicOption;
     /**
-     * Minumum fraction digits to use to format the number.
+     * Minimum fraction digits to use to format the number.
      */
     minFractionDigits?: number;
     /**
@@ -45,7 +45,7 @@ export interface INumberFormat {
      */
     fallback?: string;
     /**
-     * Displayes the specified fallback when this function returns true, by default the formatter will display
+     * Displays the specified fallback when this function returns true, by default the formatter will display
      * the fallback when the value is NaN.
      */
     displayFallback?: (value: number) => boolean;


### PR DESCRIPTION
## Description

Text correction on the following files:

```
README.md
src/utils/formatterUtils/formatterUtilsDefinitions.ts
src/components/button/button.tsx
```
