### PR TITLE
fix: Usage of Dropdown component inside dialogs

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/react';
 import '../index.css';
+import './style.css';
 
 const preview: Preview = {
     parameters: {

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -1,0 +1,4 @@
+/* Needed to hide the "Show code" button displayed on Storybook stories when opening Dialogs and Dropdowns  */
+.docs-story > div {
+  z-index: auto;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   Usage of `Dropdown` component inside a `Dialog` component
--   Remove auto-focus to Dropdown trigger on `DropdownItem` click to avoid automatically closing dialogs
+-   Remove auto-focus to `Dropdown` trigger to avoid closing dialogs on `DropdownItem` click
 
 ## [1.0.17] - 2024-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Usage of `Dropdown` component inside a `Dialog` component
+-   Remove auto-focus to Dropdown trigger on `DropdownItem` click to avoid automatically closing dialogs
+
 ## [1.0.17] - 2024-02-28
 
 ### Added

--- a/src/components/dialogs/dialog/dialogRoot/dialogRoot.tsx
+++ b/src/components/dialogs/dialog/dialogRoot/dialogRoot.tsx
@@ -69,13 +69,11 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
     return (
         <Root {...rootProps}>
             <Portal>
-                <Overlay
-                    className={classNames('fixed inset-0 z-20 bg-modal-overlay backdrop-blur-md', overlayClassName)}
-                />
+                <Overlay className={classNames('fixed inset-0 bg-modal-overlay backdrop-blur-md', overlayClassName)} />
                 <Content
                     className={classNames(
                         'fixed inset-x-2 bottom-2 mx-auto max-h-[calc(100vh-80px)] lg:bottom-auto lg:top-[120px] lg:max-h-[calc(100vh-200px)]',
-                        'z-20 flex max-w-[480px] flex-col rounded-xl border border-neutral-100 bg-neutral-0 shadow-neutral-md md:min-w-[480px]',
+                        'flex max-w-[480px] flex-col rounded-xl border border-neutral-100 bg-neutral-0 shadow-neutral-md md:min-w-[480px]',
                         containerClassName,
                     )}
                     onCloseAutoFocus={onCloseAutoFocus}

--- a/src/components/dialogs/dialogAlert/dialogAlertRoot/dialogAlertRoot.tsx
+++ b/src/components/dialogs/dialogAlert/dialogAlertRoot/dialogAlertRoot.tsx
@@ -77,13 +77,11 @@ export const DialogAlertRoot: React.FC<IDialogAlertRootProps> = (props) => {
         <Root {...rootProps}>
             <Trigger />
             <Portal>
-                <Overlay
-                    className={classNames('fixed inset-0 z-20 bg-modal-overlay backdrop-blur-md', overlayClassName)}
-                />
+                <Overlay className={classNames('fixed inset-0 bg-modal-overlay backdrop-blur-md', overlayClassName)} />
                 <Content
                     className={classNames(
                         'fixed inset-x-2 bottom-2 mx-auto max-h-[calc(100vh-80px)] lg:bottom-auto lg:top-[120px] lg:max-h-[calc(100vh-200px)]',
-                        'z-20 flex max-w-[480px] flex-col rounded-xl border border-neutral-100 bg-neutral-0 shadow-neutral-md md:min-w-[480px]',
+                        'flex max-w-[480px] flex-col rounded-xl border border-neutral-100 bg-neutral-0 shadow-neutral-md md:min-w-[480px]',
                         containerClassName,
                     )}
                     onCloseAutoFocus={onCloseAutoFocus}

--- a/src/components/dropdown/dropdownContainer.test.tsx
+++ b/src/components/dropdown/dropdownContainer.test.tsx
@@ -73,4 +73,15 @@ describe('<Dropdown.Container /> component', () => {
         await userEvent.click(trigger!);
         expect(onOpenChange).toHaveBeenCalled();
     });
+
+    it('prevents moving focus back to the trigger on menu close to be able to open dialogs on menu-item click', async () => {
+        const children = <DropdownItem>item-label</DropdownItem>;
+        render(createTestComponent({ children }));
+        const trigger = screen.getByRole('button');
+
+        await userEvent.click(trigger);
+        await userEvent.click(screen.getByRole('menuitem'));
+
+        expect(trigger).not.toHaveFocus();
+    });
 });

--- a/src/components/dropdown/dropdownContainer.tsx
+++ b/src/components/dropdown/dropdownContainer.tsx
@@ -92,6 +92,7 @@ export const DropdownContainer: React.FC<IDropdownContainerProps> = (props) => {
                         'flex min-w-48 flex-col gap-1.5 overflow-auto rounded-xl border border-neutral-100 bg-neutral-0 p-2 shadow-neutral-sm',
                         'max-h-[var(--radix-dropdown-menu-content-available-height)] max-w-[var(--radix-dropdown-menu-content-available-width)]',
                     )}
+                    onCloseAutoFocus={(event) => event.preventDefault()}
                     align={align}
                     sideOffset={4}
                 >


### PR DESCRIPTION
## Description

-  Fix usage of `Dropdown` component inside a `Dialog` component
-  Remove auto-focus to `Dropdown` trigger to avoid closing dialogs on `DropdownItem` click

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
