### PR TITLE
fix: Correctly mark peer-dependencies as external dependencies, disable export of module components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fix library build to avoid bundling peer dependencies
+-   Remove export of module components until the Aragon App migrates to Wagmi v2
+
 ## [1.0.19] - 2024-03-13
 
 ### Added

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ module.exports = [
                 plugins: [analyze ? visualizer({ filename: 'stats.cjs.html', open: true }) : undefined],
             },
         ],
-        external: Object.keys(package.dependencies),
+        external: [...Object.keys(package.dependencies), ...Object.keys(package.peerDependencies)],
         plugins: [
             // Locate and resolve node modules
             nodeResolve(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './core';
-export * from './modules';
+// Temporarily disable modules component export as Aragon App will throw error when trying to import components from
+// the ODS library. The error is caused by the ODS build because it imports the WagmiProvider that is not implemented
+// on Wagmi v1. Enable modules component export when Aragon App migrates to Wagmi v2 (https://aragonassociation.atlassian.net/browse/APP-2949)
+// export * from './modules';


### PR DESCRIPTION
## Description

- Fix library build to avoid bundling peer dependencies
- Remove export of module components until the Aragon App migrates to Wagmi v2

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
