### PR TITLE
chore: Use peer-deps plugin to avoid bundling dependencies and their eventual subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update `Tag` component primary variant styling
 -   Update Eslint rules to align usage of boolean properties
 
+### Fixed
+
+-   Library build process to avoid bundling dependencies and peer-dependencies when using subfolders import (e.g.
+    `wagmi/chains`)
+
 ## [1.0.20] - 2024-03-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^4.12.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-visualizer": "^5.12.0",
     "storybook": "^7.6.17",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 const commonjs = require('@rollup/plugin-commonjs');
 const images = require('@rollup/plugin-image');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const peerDepsExternal = require('rollup-plugin-peer-deps-external');
 const terser = require('@rollup/plugin-terser');
 const typescript = require('@rollup/plugin-typescript');
 const { visualizer } = require('rollup-plugin-visualizer');
@@ -10,7 +11,6 @@ const postcss = require('rollup-plugin-postcss');
 const tsConfig = require('./tsconfig.json');
 const { outDir } = tsConfig.compilerOptions;
 
-const package = require('./package.json');
 const analyze = process.env.ANALYZE === 'true';
 
 module.exports = [
@@ -36,8 +36,10 @@ module.exports = [
                 plugins: [analyze ? visualizer({ filename: 'stats.cjs.html', open: true }) : undefined],
             },
         ],
-        external: [...Object.keys(package.dependencies), ...Object.keys(package.peerDependencies)],
         plugins: [
+            // Mark all dependencies / peer-dependencies as external to not include them on the library build
+            peerDepsExternal({ includeDependencies: true }),
+
             // Locate and resolve node modules
             nodeResolve(),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12494,6 +12494,11 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-peer-deps-external@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
+  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+
 rollup-plugin-postcss@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz#15e9462f39475059b368ce0e49c800fa4b1f7050"


### PR DESCRIPTION
## Description

- With the introduction of wagmi hooks, I saw multiple warnings when building modules components (e.g. circular dependencies). It was because we were only setting the dependencies as externals listed on the package json without including their subfolders (e.g. only `wagmi` and not `wagmi/chains` as well). That's why I'm including a new `peerDepsExternal` plugin during the library build to mark all the dependencies and all eventual subfolders as externals. This is done internally by the plugin by building a regex for each dependency, e.g. /wagmi/,/viem/ and so on.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
