### PR TITLE
chore: Drop common-js support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Update `README` logo
 -   Bump `tar` from 6.2.0 to 6.2.1
+-   Drop `common-js` support
 
 ## [1.0.21] - 2024-04-04
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aragon/ods",
   "version": "1.0.21",
   "description": "Implementation of the Aragon's Open Design System",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.es.js",
   "types": "dist/types/src/index.d.ts",
   "license": "GPL-3.0",
   "files": [
@@ -145,10 +145,6 @@
       "import": {
         "types": "./dist/types/src/index.d.ts",
         "default": "./dist/index.es.js"
-      },
-      "require": {
-        "types": "./dist/types/src/index.d.ts",
-        "default": "./dist/index.cjs.js"
       }
     },
     "./index.css": "./index.css",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,14 +27,6 @@ module.exports = [
                 interop: 'auto',
                 plugins: [analyze ? visualizer({ filename: 'stats.es.html', open: true }) : undefined],
             },
-            {
-                format: 'cjs',
-                dir: outDir,
-                entryFileNames: '[name].[format].js',
-                sourcemap: true,
-                interop: 'auto',
-                plugins: [analyze ? visualizer({ filename: 'stats.cjs.html', open: true }) : undefined],
-            },
         ],
         plugins: [
             // Mark all dependencies / peer-dependencies as external to not include them on the library build


### PR DESCRIPTION
## Description

- Drop common-js support, current common-js build is broken as viem is ESM-only

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
