### PR TITLE
fix: APP-3104 - Clamp ProposalDataListItemStructure title to single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Bump `actions/setup-python` from 4.6.1 to 5.1.0
 -   Bump `actions/setup-node` from 3.6.0 to 4.0.2
 
+### Fixed
+
+-   `ProposalDataListItemStructure` module component to clamp title to one line
+
 ## [1.0.24] - 2024-04-23
 
 ### Added

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
@@ -53,9 +53,9 @@ export const ProposalDataListItemStructure: React.FC<IProposalDataListItemStruct
         <DataList.Item className={classNames('flex flex-col gap-y-4', className)} {...otherProps}>
             <ProposalDataListItemStatus date={date} status={status} voted={voted} />
             <div className="flex flex-col gap-y-1">
-                <p className="line-clamp-1 flex gap-x-3 text-lg leading-tight md:text-2xl">
-                    {id && <span className="text-neutral-500">{id}</span>}
-                    <span className="text-neutral-800">{title}</span>
+                <p className="flex gap-x-3 text-lg leading-tight md:text-2xl">
+                    {id && <span className="shrink-0 text-neutral-500">{id}</span>}
+                    <span className="line-clamp-1 text-neutral-800">{title}</span>
                 </p>
                 <p className="line-clamp-2 leading-normal text-neutral-500 md:text-lg">{summary}</p>
             </div>


### PR DESCRIPTION
## Description

- fixes the issue of `ProposalDataListItemStructure` title displaying on multiple lines

<!--- Set the correct ticket number -->

Task: [APP-3104](https://aragonassociation.atlassian.net/browse/APP-3104)

## Type of change

<!--- Please delete options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [ ] I have tested my code on the test network.


[APP-3104]: https://aragonassociation.atlassian.net/browse/APP-3104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ