### PR TITLE
fix: update disabled Accordion Item icon stying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Prose styling to match design system, better handling for `<code>` elements
 -   Move z-index on Collapsible optional overlay to CSS as 'auto'
+-   Fixed disabled styling of AvatarIcon for disabled `AccordionItem`
 
 ## [1.0.27] - 2024-05-08
 

--- a/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
+++ b/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
@@ -16,7 +16,7 @@ export const AccordionItemHeader = forwardRef<HTMLButtonElement, IAccordionItemH
         <RadixAccordionHeader className="flex">
             <RadixAccordionTrigger
                 className={classNames(
-                    'group flex flex-1 items-center justify-between gap-x-4 px-4 py-3 outline-none md:gap-x-6 md:px-6 md:py-5 ',
+                    'group flex flex-1 items-center justify-between gap-x-4 px-4 py-3 outline-none md:gap-x-6 md:px-6 md:py-5',
                     className,
                 )}
                 ref={ref}
@@ -25,7 +25,7 @@ export const AccordionItemHeader = forwardRef<HTMLButtonElement, IAccordionItemH
                 {children}
                 <AvatarIcon
                     icon={IconType.CHEVRON_DOWN}
-                    className="transition-transform group-data-[state=open]:rotate-180"
+                    className="transition-transform group-data-[state=open]:rotate-180 *:group-data-[disabled]:text-neutral-100"
                 />
             </RadixAccordionTrigger>
         </RadixAccordionHeader>

--- a/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
+++ b/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
@@ -25,7 +25,7 @@ export const AccordionItemHeader = forwardRef<HTMLButtonElement, IAccordionItemH
                 {children}
                 <AvatarIcon
                     icon={IconType.CHEVRON_DOWN}
-                    className="transition-transform group-data-[state=open]:rotate-180 *:group-data-[disabled]:text-neutral-100"
+                    className="shrink-0 transition-transform group-data-[state=open]:rotate-180 *:group-data-[disabled]:text-neutral-100"
                 />
             </RadixAccordionTrigger>
         </RadixAccordionHeader>


### PR DESCRIPTION
## Description

- updates the styling of the `AccordionItem` `AvatarIcon` when disabled

<!--- Set the correct ticket number -->



## Type of change

<!--- Please delete options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [ ] I have tested my code on the test network.
