### PR TITLE
fix: Fix responsiveness classes and utilities to support style for screens below sm breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   Fix responsiveness classes and utilities to support style for screens below `sm` breakpoint
+-   Export module utilities
 
 ## [1.0.31] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update sizes of `Avatar` core component
 -   Update style of `Button`, `CheckboxCard`, `InputContainer`, `RadioCard`, `Spinner` and `Switch` components
 -   Cleanup size class definitions to use `size-*` instead of `h-* w-*`
+-   Cleanup `shink-0` class usage across components
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update style of `Button`, `CheckboxCard`, `InputContainer`, `RadioCard`, `Spinner` and `Switch` components
 -   Cleanup size class definitions to use `size-*` instead of `h-* w-*`
 -   Cleanup `shink-0` class usage across components
+-   Add `data-testid` attribute to svg files
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update style of `Button`, `CheckboxCard`, `InputContainer`, `RadioCard`, `Spinner` and `Switch` components
 -   Cleanup size class definitions to use `size-*` instead of `h-* w-*`
 
+### Fixed
+
+-   Fix responsiveness classes and utilities to support style for screens below `sm` breakpoint
+
 ## [1.0.31] - 2024-05-24
 
 ### Fixed

--- a/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
+++ b/src/core/components/accordion/accordionItemHeader/accordionItemHeader.tsx
@@ -25,7 +25,7 @@ export const AccordionItemHeader = forwardRef<HTMLButtonElement, IAccordionItemH
                 {children}
                 <AvatarIcon
                     icon={IconType.CHEVRON_DOWN}
-                    className="shrink-0 transition-transform group-data-[state=open]:rotate-180 *:group-data-[disabled]:text-neutral-100"
+                    className="transition-transform group-data-[state=open]:rotate-180 *:group-data-[disabled]:text-neutral-100"
                 />
             </RadixAccordionTrigger>
         </RadixAccordionHeader>

--- a/src/core/components/avatars/avatar/avatar.tsx
+++ b/src/core/components/avatars/avatar/avatar.tsx
@@ -26,35 +26,40 @@ export interface IAvatarProps extends ComponentPropsWithoutRef<'img'> {
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarSize> = {
     sm: {
-        sm: 'size-6',
+        default: 'size-6',
+        sm: 'sm:size-6',
         md: 'md:size-6',
         lg: 'lg:size-6',
         xl: 'xl:size-6',
         '2xl': '2xl:size-6',
     },
     md: {
-        sm: 'size-8',
+        default: 'size-8',
+        sm: 'sm:size-8',
         md: 'md:size-8',
         lg: 'lg:size-8',
         xl: 'xl:size-8',
         '2xl': '2xl:size-8',
     },
     lg: {
-        sm: 'size-10',
+        default: 'size-10',
+        sm: 'sm:size-10',
         md: 'md:size-10',
         lg: 'lg:size-10',
         xl: 'xl:size-10',
         '2xl': '2xl:size-10',
     },
     xl: {
-        sm: 'size-14',
+        default: 'size-14',
+        sm: 'sm:size-14',
         md: 'md:size-14',
         lg: 'lg:size-14',
         xl: 'xl:size-14',
         '2xl': '2xl:size-14',
     },
     '2xl': {
-        sm: 'size-16',
+        default: 'size-16',
+        sm: 'sm:size-16',
         md: 'md:size-16',
         lg: 'lg:size-16',
         xl: 'xl:size-16',
@@ -66,7 +71,7 @@ const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarSize> = {
  * Avatar component
  */
 export const Avatar: React.FC<IAvatarProps> = (props) => {
-    const { alt = 'avatar', className, fallback, responsiveSize = {}, size = 'sm', ...imageProps } = props;
+    const { alt = 'avatar', className, fallback, responsiveSize, size = 'sm', ...imageProps } = props;
 
     const [imgLoading, setImgLoading] = useState(true);
 

--- a/src/core/components/avatars/avatarIcon/avatarIcon.tsx
+++ b/src/core/components/avatars/avatarIcon/avatarIcon.tsx
@@ -84,7 +84,7 @@ export const AvatarIcon: React.FC<IAvatarIconProps> = (props) => {
     const { className, icon, variant = 'neutral', size = 'sm', responsiveSize, backgroundWhite, ...rest } = props;
 
     const containerClasses = classNames(
-        'flex items-center justify-center rounded-full',
+        'flex shrink-0 items-center justify-center rounded-full',
         avatarVariantToContainerClassNames[backgroundWhite ? 'white' : variant],
         responsiveUtils.generateClassNames(size, responsiveSize, responsiveSizeClasses),
         className,

--- a/src/core/components/avatars/avatarIcon/avatarIcon.tsx
+++ b/src/core/components/avatars/avatarIcon/avatarIcon.tsx
@@ -55,21 +55,24 @@ const avatarVariantToContainerClassNames: Record<AvatarIconVariant | 'white', st
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarIconSize> = {
     sm: {
-        sm: 'size-6',
+        default: 'size-6',
+        sm: 'sm:size-6',
         md: 'md:size-6',
         lg: 'lg:size-6',
         xl: 'xl:size-6',
         '2xl': '2xl:size-6',
     },
     md: {
-        sm: 'size-8',
+        default: 'size-8',
+        sm: 'sm:size-8',
         md: 'md:size-8',
         lg: 'lg:size-8',
         xl: 'xl:size-8',
         '2xl': '2xl:size-8',
     },
     lg: {
-        sm: 'size-10',
+        default: 'size-10',
+        sm: 'sm:size-10',
         md: 'md:size-10',
         lg: 'lg:size-10',
         xl: 'xl:size-10',
@@ -78,7 +81,7 @@ const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarIconSize> = {
 };
 
 export const AvatarIcon: React.FC<IAvatarIconProps> = (props) => {
-    const { className, icon, variant = 'neutral', size = 'sm', responsiveSize = {}, backgroundWhite, ...rest } = props;
+    const { className, icon, variant = 'neutral', size = 'sm', responsiveSize, backgroundWhite, ...rest } = props;
 
     const containerClasses = classNames(
         'flex items-center justify-center rounded-full',

--- a/src/core/components/button/button.tsx
+++ b/src/core/components/button/button.tsx
@@ -83,21 +83,24 @@ const variantToSpinnerVariant: Record<ButtonVariant, SpinnerVariant> = {
 
 const responsiveSizeClassNames: ResponsiveAttributeClassMap<ButtonSize> = {
     sm: {
-        sm: 'h-[32px] text-sm rounded-lg gap-0.5',
+        default: 'h-[32px] text-sm rounded-lg gap-0.5',
+        sm: 'sm:h-[32px] sm:text-sm sm:rounded-lg sm:gap-0.5',
         md: 'md:h-[32px] md:text-sm md:rounded-lg md:gap-0.5',
         lg: 'lg:h-[32px] lg:text-sm lg:rounded-lg lg:gap-0.5',
         xl: 'xl:h-[32px] xl:text-sm xl:rounded-lg xl:gap-0.5',
         '2xl': '2xl:h-[32px] 2xl:text-sm 2xl:rounded-lg 2xl:gap-0.5',
     },
     md: {
-        sm: 'h-[40px] text-base rounded-xl gap-1',
+        default: 'h-[40px] text-base rounded-xl gap-1',
+        sm: 'sm:h-[40px] sm:text-base sm:rounded-xl sm:gap-1',
         md: 'md:h-[40px] md:text-base md:rounded-xl md:gap-1',
         lg: 'lg:h-[40px] lg:text-base lg:rounded-xl lg:gap-1',
         xl: 'xl:h-[40px] xl:text-base xl:rounded-xl xl:gap-1',
         '2xl': '2xl:h-[40px] 2xl:text-base 2xl:rounded-xl 2xl:gap-1',
     },
     lg: {
-        sm: 'h-[48px] text-base rounded-xl gap-1',
+        default: 'h-[48px] text-base rounded-xl gap-1',
+        sm: 'sm:h-[48px] sm:text-base sm:rounded-xl sm:gap-1',
         md: 'md:h-[48px] md:text-base md:rounded-xl md:gap-1',
         lg: 'lg:h-[48px] lg:text-base lg:rounded-xl lg:gap-1',
         xl: 'xl:h-[48px] xl:text-base xl:rounded-xl xl:gap-1',
@@ -107,21 +110,24 @@ const responsiveSizeClassNames: ResponsiveAttributeClassMap<ButtonSize> = {
 
 const responsiveDefaultContextClassNames: ResponsiveAttributeClassMap<ButtonSize> = {
     sm: {
-        sm: 'min-w-[80px] px-2',
+        default: 'min-w-[80px] px-2',
+        sm: 'sm:min-w-[80px] sm:px-2',
         md: 'md:min-w-[80px] md:px-2',
         lg: 'lg:min-w-[80px] lg:px-2',
         xl: 'xl:min-w-[80px] xl:px-2',
         '2xl': '2xl:min-w-[80px] 2xl:px-2',
     },
     md: {
-        sm: 'min-w-[96px] px-3',
+        default: 'min-w-[96px] px-3',
+        sm: 'sm:min-w-[96px] sm:px-3',
         md: 'md:min-w-[96px] md:px-3',
         lg: 'lg:min-w-[96px] lg:px-3',
         xl: 'xl:min-w-[96px] xl:px-3',
         '2xl': '2xl:min-w-[96px] 2xl:px-3',
     },
     lg: {
-        sm: 'min-w-[112px] px-4',
+        default: 'min-w-[112px] px-4',
+        sm: 'sm:min-w-[112px] sm:px-4',
         md: 'md:min-w-[112px] md:px-4',
         lg: 'lg:min-w-[112px] lg:px-4',
         xl: 'xl:min-w-[112px] xl:px-4',
@@ -131,21 +137,24 @@ const responsiveDefaultContextClassNames: ResponsiveAttributeClassMap<ButtonSize
 
 const responsiveOnlyIconContextClassNames: ResponsiveAttributeClassMap<ButtonSize> = {
     sm: {
-        sm: 'w-[32px]',
+        default: 'w-[32px]',
+        sm: 'sm:w-[32px]',
         md: 'md:w-[32px]',
         lg: 'lg:w-[32px]',
         xl: 'xl:w-[32px]',
         '2xl': '2xl:w-[32px]',
     },
     md: {
-        sm: 'w-[40px]',
+        default: 'w-[40px]',
+        sm: 'sm:w-[40px]',
         md: 'md:w-[40px]',
         lg: 'lg:w-[40px]',
         xl: 'xl:w-[40px]',
         '2xl': '2xl:w-[40px]',
     },
     lg: {
-        sm: 'w-[48px]',
+        default: 'w-[48px]',
+        sm: 'sm:w-[48px]',
         md: 'md:w-[48px]',
         lg: 'lg:w-[48px]',
         xl: 'xl:w-[48px]',

--- a/src/core/components/dataList/dataListFilter/dataListFilter.tsx
+++ b/src/core/components/dataList/dataListFilter/dataListFilter.tsx
@@ -93,14 +93,9 @@ export const DataListFilter: React.FC<IDataListFilterProps> = (props) => {
                 )}
             >
                 {state !== 'loading' && (
-                    <AvatarIcon
-                        icon={IconType.SEARCH}
-                        size="md"
-                        className="shrink-0"
-                        variant={isFocused ? 'primary' : 'neutral'}
-                    />
+                    <AvatarIcon icon={IconType.SEARCH} size="md" variant={isFocused ? 'primary' : 'neutral'} />
                 )}
-                {state === 'loading' && <Spinner size="lg" variant="primary" className="m-1 shrink-0" />}
+                {state === 'loading' && <Spinner size="lg" variant="primary" className="m-1" />}
                 <input
                     type="search"
                     className={classNames(

--- a/src/core/components/icon/icon.tsx
+++ b/src/core/components/icon/icon.tsx
@@ -57,5 +57,11 @@ export const Icon: React.FC<IIconProps> = (props) => {
 
     const sizeClassNames = responsiveUtils.generateClassNames(size, responsiveSize, responsiveSizeClassNames);
 
-    return <IconComponent className={classNames('shrink-0', sizeClassNames, className)} {...otherProps} />;
+    return (
+        <IconComponent
+            className={classNames('shrink-0', sizeClassNames, className)}
+            data-testid={icon}
+            {...otherProps}
+        />
+    );
 };

--- a/src/core/components/icon/icon.tsx
+++ b/src/core/components/icon/icon.tsx
@@ -25,21 +25,24 @@ export interface IIconProps extends SVGProps<SVGSVGElement> {
 
 const responsiveSizeClassNames: ResponsiveAttributeClassMap<IconSize> = {
     sm: {
-        sm: 'size-3',
+        default: 'size-3',
+        sm: 'sm:size-3',
         md: 'md:size-3',
         lg: 'lg:size-3',
         xl: 'xl:size-3',
         '2xl': '2xl:size-3',
     },
     md: {
-        sm: 'size-4',
+        default: 'size-4',
+        sm: 'sm:size-4',
         md: 'md:size-4',
         lg: 'lg:size-4',
         xl: 'xl:size-4',
         '2xl': '2xl:size-4',
     },
     lg: {
-        sm: 'size-5',
+        default: 'size-5',
+        sm: 'sm:size-5',
         md: 'md:size-5',
         lg: 'lg:size-5',
         xl: 'xl:size-5',
@@ -48,7 +51,7 @@ const responsiveSizeClassNames: ResponsiveAttributeClassMap<IconSize> = {
 };
 
 export const Icon: React.FC<IIconProps> = (props) => {
-    const { icon, size = 'md', className, responsiveSize = {}, ...otherProps } = props;
+    const { icon, size = 'md', className, responsiveSize, ...otherProps } = props;
 
     const IconComponent = iconList[icon];
 

--- a/src/core/components/illustrations/illustrationHuman/illustrationHuman.tsx
+++ b/src/core/components/illustrations/illustrationHuman/illustrationHuman.tsx
@@ -76,13 +76,14 @@ export const IllustrationHuman: React.FC<IIllustrationHumanProps> = (props) => {
 
     return (
         <div className={classNames('relative', className)} style={computedStyle} {...otherProps}>
-            <Body />
-            <Expression {...commonProps} />
-            {Hairs && <Hairs {...commonProps} />}
-            {Sunglasses && <Sunglasses {...commonProps} />}
-            {Accessory && <Accessory {...commonProps} />}
+            <Body data-testid={body} />
+            <Expression data-testid={expression} {...commonProps} />
+            {Hairs && <Hairs data-testid={hairs} {...commonProps} />}
+            {Sunglasses && <Sunglasses data-testid={sunglasses} {...commonProps} />}
+            {Accessory && <Accessory data-testid={accessory} {...commonProps} />}
             {Object && (
                 <Object
+                    data-testid={object}
                     className={classNames(
                         'absolute top-0 h-[70%]',
                         { 'left-0': objectPosition === 'left' },

--- a/src/core/components/illustrations/illustrationObject/illustrationObject.tsx
+++ b/src/core/components/illustrations/illustrationObject/illustrationObject.tsx
@@ -13,5 +13,5 @@ export const IllustrationObject: React.FC<IIllustrationObjectProps> = (props) =>
     const { object, ...otherProps } = props;
     const IllustrationObject = illustrationObjectList[object];
 
-    return <IllustrationObject {...otherProps} />;
+    return <IllustrationObject data-testid={object} {...otherProps} />;
 };

--- a/src/core/components/progress/progress.tsx
+++ b/src/core/components/progress/progress.tsx
@@ -6,14 +6,16 @@ import type { IProgressProps, ProgressSize } from './progress.api';
 
 const responsiveSizeClassNames: ResponsiveAttributeClassMap<ProgressSize> = {
     sm: {
-        sm: 'h-1',
+        default: 'h-1',
+        sm: 'sm:h-1',
         md: 'md:h-1',
         lg: 'lg:h-1',
         xl: 'xl:h-1',
         '2xl': '2xl:h-1',
     },
     md: {
-        sm: 'h-2',
+        default: 'h-2',
+        sm: 'sm:h-2',
         md: 'md:h-2',
         lg: 'lg:h-2',
         xl: 'xl:h-2',
@@ -22,7 +24,7 @@ const responsiveSizeClassNames: ResponsiveAttributeClassMap<ProgressSize> = {
 };
 
 export const Progress: React.FC<IProgressProps> = (props) => {
-    const { value, size = 'md', responsiveSize = {}, className, ...otherProps } = props;
+    const { value, size = 'md', responsiveSize, className, ...otherProps } = props;
 
     const processedValue = Math.min(Math.max(1, value), 100);
 

--- a/src/core/components/spinner/spinner.tsx
+++ b/src/core/components/spinner/spinner.tsx
@@ -25,28 +25,32 @@ export interface ISpinnerProps extends HTMLAttributes<HTMLDivElement> {
 
 const responsiveSizeClassNames: ResponsiveAttributeClassMap<SpinnerSize> = {
     sm: {
-        sm: 'size-4 border-[1.6px]',
+        default: 'size-4 border-[1.6px]',
+        sm: 'sm:size-4 sm:border-[1.6px]',
         md: 'md:size-4 md:border-[1.6px]',
         lg: 'lg:size-4 lg:border-[1.6px]',
         xl: 'xl:size-4 xl:border-[1.6px]',
         '2xl': '2xl:size-4 2xl:border-[1.6px]',
     },
     md: {
-        sm: 'size-5 border-2',
+        default: 'size-5 border-2',
+        sm: 'sm:size-5 sm:border-2',
         md: 'md:size-5 md:border-2',
         lg: 'lg:size-5 lg:border-2',
         xl: 'xl:size-5 xl:border-2',
         '2xl': '2xl:size-5 2xl:border-2',
     },
     lg: {
-        sm: 'size-6 border-[2.4px]',
+        default: 'size-6 border-[2.4px]',
+        sm: 'sm:size-6 sm:border-[2.4px]',
         md: 'md:size-6 md:border-[2.4px]',
         lg: 'lg:size-6 lg:border-[2.4px]',
         xl: 'xl:size-6 xl:border-[2.4px]',
         '2xl': '2xl:size-6 2xl:border-[2.4px]',
     },
     xl: {
-        sm: 'size-8 border-[3.2px]',
+        default: 'size-8 border-[3.2px]',
+        sm: 'sm:size-8 sm:border-[3.2px]',
         md: 'md:size-8 md:border-[3.2px]',
         lg: 'lg:size-8 lg:border-[3.2px]',
         xl: 'xl:size-8 xl:border-[3.2px]',
@@ -67,7 +71,7 @@ const variantToClassNames: Record<SpinnerVariant, string> = {
  * Spinner UI component
  */
 export const Spinner: React.FC<ISpinnerProps> = (props) => {
-    const { size = 'md', responsiveSize = {}, variant = 'neutral', className, ...otherProps } = props;
+    const { size = 'md', responsiveSize, variant = 'neutral', className, ...otherProps } = props;
 
     const sizeClassNames = responsiveUtils.generateClassNames(size, responsiveSize, responsiveSizeClassNames);
 

--- a/src/core/components/spinner/spinner.tsx
+++ b/src/core/components/spinner/spinner.tsx
@@ -76,7 +76,7 @@ export const Spinner: React.FC<ISpinnerProps> = (props) => {
     const sizeClassNames = responsiveUtils.generateClassNames(size, responsiveSize, responsiveSizeClassNames);
 
     const spinnerClassNames = classNames(
-        'animate-spin rounded-full',
+        'shrink-0 animate-spin rounded-full',
         variantToClassNames[variant],
         sizeClassNames,
         className,

--- a/src/core/components/states/stateSkeletonBar/stateSkeletonBar.tsx
+++ b/src/core/components/states/stateSkeletonBar/stateSkeletonBar.tsx
@@ -30,15 +30,15 @@ export interface IStateSkeletonBarProps extends ComponentPropsWithoutRef<'span'>
 }
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<StateSkeletonBarSize> = {
-    sm: { sm: 'h-3', md: 'md:h-3', lg: 'lg:h-3', xl: 'xl:h-3', '2xl': '2xl:h-3' },
-    md: { sm: 'h-4', md: 'md:h-4', lg: 'lg:h-4', xl: 'xl:h-4', '2xl': '2xl:h-4' },
-    lg: { sm: 'h-5', md: 'md:h-5', lg: 'lg:h-5', xl: 'xl:h-5', '2xl': '2xl:h-5' },
-    xl: { sm: 'h-6', md: 'md:h-6', lg: 'lg:h-6', xl: 'xl:h-6', '2xl': '2xl:h-6' },
-    '2xl': { sm: 'h-8', md: 'md:h-8', lg: 'lg:h-8', xl: 'xl:h-8', '2xl': '2xl:h-8' },
+    sm: { default: 'h-3', sm: 'sm:h-3', md: 'md:h-3', lg: 'lg:h-3', xl: 'xl:h-3', '2xl': '2xl:h-3' },
+    md: { default: 'h-4', sm: 'sm:h-4', md: 'md:h-4', lg: 'lg:h-4', xl: 'xl:h-4', '2xl': '2xl:h-4' },
+    lg: { default: 'h-5', sm: 'sm:h-5', md: 'md:h-5', lg: 'lg:h-5', xl: 'xl:h-5', '2xl': '2xl:h-5' },
+    xl: { default: 'h-6', sm: 'sm:h-6', md: 'md:h-6', lg: 'lg:h-6', xl: 'xl:h-6', '2xl': '2xl:h-6' },
+    '2xl': { default: 'h-8', sm: 'sm:h-8', md: 'md:h-8', lg: 'lg:h-8', xl: 'xl:h-8', '2xl': '2xl:h-8' },
 };
 
 export const StateSkeletonBar = forwardRef<HTMLDivElement, IStateSkeletonBarProps>((props, ref) => {
-    const { className, responsiveSize = {}, size = 'md', style, width = 160, ...otherProps } = props;
+    const { className, responsiveSize, size = 'md', style, width = 160, ...otherProps } = props;
 
     const classes = classNames(
         'animate-pulse rounded-full bg-neutral-50',

--- a/src/core/components/states/stateSkeletonCircular/stateSkeletonCircular.tsx
+++ b/src/core/components/states/stateSkeletonCircular/stateSkeletonCircular.tsx
@@ -18,15 +18,50 @@ export interface IStateSkeletonCircularProps extends ComponentPropsWithoutRef<'s
 }
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<StateSkeletonCircularSize> = {
-    sm: { sm: 'size-6', md: 'md:size-6', lg: 'lg:size-6', xl: 'xl:size-6', '2xl': '2xl:size-6' },
-    md: { sm: 'size-8', md: 'md:size-8', lg: 'lg:size-8', xl: 'xl:size-8', '2xl': '2xl:size-8' },
-    lg: { sm: 'size-10', md: 'md:size-10', lg: 'lg:size-10', xl: 'xl:size-10', '2xl': '2xl:size-10' },
-    xl: { sm: 'size-14', md: 'md:size-14', lg: 'lg:size-14', xl: 'xl:size-14', '2xl': '2xl:size-14' },
-    '2xl': { sm: 'size-16', md: 'md:size-16', lg: 'lg:size-16', xl: 'xl:size-16', '2xl': '2xl:size-16' },
+    sm: {
+        default: 'size-6',
+        sm: 'sm:size-6',
+        md: 'md:size-6',
+        lg: 'lg:size-6',
+        xl: 'xl:size-6',
+        '2xl': '2xl:size-6',
+    },
+    md: {
+        default: 'size-8',
+        sm: 'sm:size-8',
+        md: 'md:size-8',
+        lg: 'lg:size-8',
+        xl: 'xl:size-8',
+        '2xl': '2xl:size-8',
+    },
+    lg: {
+        default: 'size-10',
+        sm: 'sm:size-10',
+        md: 'md:size-10',
+        lg: 'lg:size-10',
+        xl: 'xl:size-10',
+        '2xl': '2xl:size-10',
+    },
+    xl: {
+        default: 'size-14',
+        sm: 'sm:size-14',
+        md: 'md:size-14',
+        lg: 'lg:size-14',
+        xl: 'xl:size-14',
+        '2xl': '2xl:size-14',
+    },
+    '2xl': {
+        default: 'size-16',
+        sm: 'sm:size-16',
+        md: 'md:size-16',
+        lg: 'lg:size-16',
+        xl: 'xl:size-16',
+        '2xl': '2xl:size-16',
+    },
 };
 
 export const StateSkeletonCircular = forwardRef<HTMLDivElement, IStateSkeletonCircularProps>((props, ref) => {
-    const { className, responsiveSize = {}, size = 'md', ...otherProps } = props;
+    const { className, responsiveSize, size = 'md', ...otherProps } = props;
 
     const classes = classNames(
         'animate-pulse rounded-full bg-neutral-50',

--- a/src/core/components/states/stateSkeletonCircular/stateSkeletonCircular.tsx
+++ b/src/core/components/states/stateSkeletonCircular/stateSkeletonCircular.tsx
@@ -64,7 +64,7 @@ export const StateSkeletonCircular = forwardRef<HTMLDivElement, IStateSkeletonCi
     const { className, responsiveSize, size = 'md', ...otherProps } = props;
 
     const classes = classNames(
-        'animate-pulse rounded-full bg-neutral-50',
+        'shrink-0 animate-pulse rounded-full bg-neutral-50',
         responsiveUtils.generateClassNames(size, responsiveSize, responsiveSizeClasses),
         className,
     );

--- a/src/core/test/svgTransform.js
+++ b/src/core/test/svgTransform.js
@@ -6,30 +6,19 @@ const fileNameToComponent = (name) =>
         .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
         .join('');
 
-const fileNameToIcon = (name) =>
-    path
-        .basename(name, '.svg')
-        .split(/\W+/)
-        .map((part) => part.toUpperCase())
-        .join('_');
-
 const transform = (src, filePath) => {
     if (path.extname(filePath) !== '.svg') {
         return src;
     }
 
     const componentName = fileNameToComponent(filePath);
-    const iconName = fileNameToIcon(filePath);
 
     return {
         code: `
             const React = require('react');
 
             function ${componentName}(props) {
-                return React.createElement(
-                    'svg',
-                    Object.assign({}, props, {'data-testid': '${iconName}'})
-                );
+                return React.createElement('svg', props);
             }
 
             module.exports = ${componentName};

--- a/src/core/types/responsive.ts
+++ b/src/core/types/responsive.ts
@@ -1,4 +1,4 @@
-export type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type Breakpoint = 'default' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
 /**
  * Size key of a component that is responsive.
@@ -16,16 +16,18 @@ export type ResponsiveAttribute<TSize> = Partial<Record<Breakpoint, TSize>>;
  * Example:
  *
  * type ButtonSize = 'big' | 'small';
- * type Breakpoint = 'sm' | 'md' | 'lg';
+ * type Breakpoint = 'default' | 'sm' | 'md' | 'lg';
  *
  * const responsiveButtonSizeClassNames: ResponsiveAttributeClassMap<ButtonSize> = {
  *      'big': {
- *          'sm': 'w-40',
+ *          'default': 'w-40',
+ *          'sm': 'sm:w-40',
  *          'md': 'md:w-40',
  *          'lg': 'lg:w-40',
  *      },
  *      'small': {
- *          'sm': 'w-20',
+ *          'default': 'w-20',
+ *          'sm': 'sm:w-20',
  *          'md': 'md:w-20',
  *          'lg': 'lg-w-20',
  *      }

--- a/src/core/utils/responsiveUtils/responsiveUtils.test.ts
+++ b/src/core/utils/responsiveUtils/responsiveUtils.test.ts
@@ -5,21 +5,24 @@ describe('responsive utils', () => {
     describe('generateClassNames', () => {
         const classes: ResponsiveAttributeClassMap<'sm' | 'md' | 'lg'> = {
             sm: {
-                sm: 'w-3 h-3',
+                default: 'w-3 h-3',
+                sm: 'sm:w-3 sm:h-3',
                 md: 'md:w-3 md:h-3',
                 lg: 'lg:w-3 lg:h-3',
                 xl: 'xl:w-3 xl:h-3',
                 '2xl': '2xl:w-3 2xl:h-3',
             },
             md: {
-                sm: 'w-4 h-4',
+                default: 'w-4 h-4',
+                sm: 'sm:w-4 sm:h-4',
                 md: 'md:w-4 md:h-4',
                 lg: 'lg:w-4 lg:h-4',
                 xl: 'xl:w-4 xl:h-4',
                 '2xl': '2xl:w-4 2xl:h-4',
             },
             lg: {
-                sm: 'w-5 h-5',
+                default: 'w-5 h-5',
+                sm: 'sm:w-5 sm:h-5',
                 md: 'md:w-5 md:h-5',
                 lg: 'lg:w-5 lg:h-5',
                 xl: 'xl:w-5 xl:h-5',
@@ -33,14 +36,19 @@ describe('responsive utils', () => {
             { size: 'sm', responsiveSize: { lg: 'lg' }, expected: 'w-3 h-3 lg:w-5 lg:h-5' },
             { size: 'sm', responsiveSize: { md: 'md', lg: 'lg' }, expected: 'w-3 h-3 md:w-4 md:h-4 lg:w-5 lg:h-5' },
             { size: 'sm', responsiveSize: { xl: 'lg' }, expected: 'w-3 h-3 xl:w-5 xl:h-5' },
+            {
+                size: 'sm',
+                responsiveSize: { xl: 'md', '2xl': 'lg' },
+                expected: 'w-3 h-3 xl:w-4 xl:h-4 2xl:w-5 2xl:h-5',
+            },
             { size: 'md', responsiveSize: {}, expected: 'w-4 h-4' },
-            { size: 'md', responsiveSize: { sm: 'sm' }, expected: 'w-3 h-3' },
+            { size: 'md', responsiveSize: { sm: 'sm' }, expected: 'w-4 h-4 sm:w-3 sm:h-3' },
             { size: 'md', responsiveSize: { lg: 'lg' }, expected: 'w-4 h-4 lg:w-5 lg:h-5' },
-            { size: 'md', responsiveSize: { sm: 'sm', lg: 'lg' }, expected: 'w-3 h-3 lg:w-5 lg:h-5' },
+            { size: 'md', responsiveSize: { sm: 'sm', lg: 'lg' }, expected: 'w-4 h-4 sm:w-3 sm:h-3 lg:w-5 lg:h-5' },
             { size: 'lg', responsiveSize: {}, expected: 'w-5 h-5' },
-            { size: 'lg', responsiveSize: { sm: 'sm' }, expected: 'w-3 h-3' },
+            { size: 'lg', responsiveSize: { sm: 'sm' }, expected: 'w-5 h-5 sm:w-3 sm:h-3' },
             { size: 'lg', responsiveSize: { md: 'md' }, expected: 'w-5 h-5 md:w-4 md:h-4' },
-            { size: 'lg', responsiveSize: { sm: 'sm', md: 'md' }, expected: 'w-3 h-3 md:w-4 md:h-4' },
+            { size: 'lg', responsiveSize: { sm: 'sm', md: 'md' }, expected: 'w-5 h-5 sm:w-3 sm:h-3 md:w-4 md:h-4' },
         ] as const)(
             'correctly builds the reponsive classnames for $size and $responsiveSize',
             ({ size, responsiveSize, expected }) => {

--- a/src/core/utils/responsiveUtils/responsiveUtils.ts
+++ b/src/core/utils/responsiveUtils/responsiveUtils.ts
@@ -4,19 +4,19 @@ import type { ResponsiveAttribute, ResponsiveAttributeClassMap, ResponsiveSizeKe
 class ResponsiveUtils {
     generateClassNames<TSize extends ResponsiveSizeKey>(
         size: TSize,
-        responsiveSize: ResponsiveAttribute<TSize>,
+        responsiveSize: ResponsiveAttribute<TSize> = {},
         classes: ResponsiveAttributeClassMap<TSize>,
     ): string {
-        const defaultSize = classes[size].sm;
+        const { default: defaultClass } = classes[size];
 
         // Override with responsive size if specified.
-        const smClass = responsiveSize.sm ? classes[responsiveSize.sm].sm : defaultSize;
+        const smClass = responsiveSize.sm ? classes[responsiveSize.sm].sm : '';
         const mdClass = responsiveSize.md ? classes[responsiveSize.md].md : '';
         const lgClass = responsiveSize.lg ? classes[responsiveSize.lg].lg : '';
         const xlClass = responsiveSize.xl ? classes[responsiveSize.xl].xl : '';
         const twoXlClass = responsiveSize['2xl'] ? classes[responsiveSize['2xl']]['2xl'] : '';
 
-        return classNames(smClass, mdClass, lgClass, xlClass, twoXlClass);
+        return classNames(defaultClass, smClass, mdClass, lgClass, xlClass, twoXlClass);
     }
 }
 

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.tsx
@@ -17,7 +17,7 @@ export const AssetDataListItemSkeleton: React.FC<IAssetDataListItemSkeletonProps
             {...otherProps}
         >
             <div className="flex w-full items-center gap-x-3 py-0.5 md:py-1.5">
-                <StateSkeletonCircular className="shrink-0" responsiveSize={{ md: 'lg' }} />
+                <StateSkeletonCircular responsiveSize={{ md: 'lg' }} />
                 <div className="flex w-full justify-between">
                     <div className="flex w-full flex-col gap-y-1 md:gap-y-1.5">
                         <StateSkeletonBar className="shrink-0" responsiveSize={{ md: 'lg' }} width="100%" />

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.tsx
@@ -20,7 +20,7 @@ export const DaoDataListItemSkeleton: React.FC<IDaoDataListItemSkeletonProps> = 
                         <StateSkeletonBar size="xl" responsiveSize={{ md: '2xl' }} width="100%" />
                         <StateSkeletonBar responsiveSize={{ md: 'lg' }} width="50%" />
                     </div>
-                    <StateSkeletonCircular className="shrink-0" size="lg" />
+                    <StateSkeletonCircular size="lg" />
                 </div>
                 <div className="flex flex-col gap-y-2">
                     <StateSkeletonBar responsiveSize={{ md: 'lg' }} width="100%" />

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.tsx
@@ -6,7 +6,7 @@ export const TransactionDataListItemSkeleton: React.FC<ITransactionDataListItemS
     return (
         <DataList.Item tabIndex={0} aria-busy="true" aria-label="loading" {...props}>
             <div className="flex w-full items-center justify-between gap-x-3 border border-neutral-0 py-3 md:py-3.5">
-                <StateSkeletonCircular className="shrink-0" size="sm" responsiveSize={{ md: 'md' }} />
+                <StateSkeletonCircular size="sm" responsiveSize={{ md: 'md' }} />
                 <div className="flex w-full items-center gap-x-3 md:gap-x-4">
                     <div className="flex w-full flex-col items-start gap-y-1 md:w-3/4">
                         <StateSkeletonBar width="100%" responsiveSize={{ md: 'lg' }} />

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
@@ -80,19 +80,13 @@ export const TransactionDataListItemStructure: React.FC<ITransactionDataListItem
                 <div className="flex items-center gap-x-3 md:gap-x-4">
                     {status === TransactionStatus.SUCCESS && (
                         <AvatarIcon
-                            className="shrink-0"
                             variant={txVariantList[type]}
                             icon={txIconTypeList[type]}
                             responsiveSize={{ md: 'md' }}
                         />
                     )}
                     {status === TransactionStatus.FAILED && (
-                        <AvatarIcon
-                            className="shrink-0"
-                            variant="critical"
-                            icon={IconType.CLOSE}
-                            responsiveSize={{ md: 'md' }}
-                        />
+                        <AvatarIcon variant="critical" icon={IconType.CLOSE} responsiveSize={{ md: 'md' }} />
                     )}
                     {status === TransactionStatus.PENDING && (
                         <div className="flex size-6 shrink-0 items-center justify-center md:size-8">

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.tsx
@@ -8,7 +8,7 @@ export const VoteDataListItemSkeleton: React.FC<IVoteDataListItemSkeletonProps> 
     return (
         <DataList.Item tabIndex={0} aria-busy="true" aria-label="loading" {...otherProps}>
             <div className="flex items-center gap-x-3 py-1 md:gap-x-4 md:py-0.5">
-                <StateSkeletonCircular className="shrink-0" responsiveSize={{ md: 'md' }} />
+                <StateSkeletonCircular responsiveSize={{ md: 'md' }} />
                 <div className="flex w-full flex-col gap-y-1 md:gap-y-1.5">
                     <StateSkeletonBar width="60%" responsiveSize={{ md: 'lg' }} />
                     <StateSkeletonBar width="25%" responsiveSize={{ md: 'lg' }} />

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
 export * from './types';
+export * from './utils';


### PR DESCRIPTION
## Description

- Fix responsiveness classes and utilities to support style for screens below sm breakpoint
- Cleanup usage of `shrink-0` class name

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
