### PR TITLE
feat(APP-2855): Migrate to userEvent from fireEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update minor and patch dependencies of Github workflows
 -   Update minor and patch NPM dependencies
 -   Update `yarn` version to `4.3.0`
+-   Update unit tests to use userEvent instead of fireEvent
 
 ## [1.0.33] - 2024-06-06
 

--- a/src/core/components/button/button.test.tsx
+++ b/src/core/components/button/button.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { IconType } from '../icon';
 import { Button } from './button';
 import type { IButtonProps } from './button.api';
@@ -66,31 +67,34 @@ describe('<Button /> component', () => {
         expect(link.href).toEqual(href);
     });
 
-    it('disables the button on disabled state', () => {
+    it('disables the button on disabled state', async () => {
+        const user = userEvent.setup();
         const onClick = jest.fn();
         render(createTestComponent({ disabled: true, onClick }));
         const button = screen.getByRole<HTMLButtonElement>('button');
         expect(button).toBeDisabled();
         expect(button).toHaveAttribute('aria-disabled', 'true');
-        fireEvent.click(button);
+        await user.click(button);
         expect(onClick).not.toHaveBeenCalled();
     });
 
-    it('disables the button link on disabled state', () => {
+    it('disables the button link on disabled state', async () => {
+        const user = userEvent.setup();
         const onClick = jest.fn();
         const href = '/test';
         render(createTestComponent({ disabled: true, href, onClick }));
         const link = screen.getByRole<HTMLAnchorElement>('link');
         expect(link).toHaveAttribute('aria-disabled', 'true');
-        fireEvent.click(link);
+        await user.click(link);
         expect(onClick).not.toHaveBeenCalled();
     });
 
-    it('supports the onClick property on link variant', () => {
+    it('supports the onClick property on link variant', async () => {
+        const user = userEvent.setup();
         const onClick = jest.fn();
         const href = '/test';
         render(createTestComponent({ onClick, href }));
-        fireEvent.click(screen.getByRole('link'));
+        await user.click(screen.getByRole('link'));
         expect(onClick).toHaveBeenCalled();
     });
 });

--- a/src/core/components/cards/cardSummary/cardSummary.test.tsx
+++ b/src/core/components/cards/cardSummary/cardSummary.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { IconType } from '../../icon';
 import { CardSummary } from './cardSummary';
 import type { ICardSummaryProps } from './cardSummary.api';
@@ -30,7 +31,8 @@ describe('<CardSummary /> component', () => {
         expect(screen.getByTestId(icon)).toBeInTheDocument();
     });
 
-    it('renders the specified action', () => {
+    it('renders the specified action', async () => {
+        const user = userEvent.setup();
         const label = 'action-test';
         const onClick = jest.fn();
         const action = { label, onClick };
@@ -39,7 +41,7 @@ describe('<CardSummary /> component', () => {
         const button = screen.getByRole('button', { name: label });
         expect(button).toBeInTheDocument();
 
-        fireEvent.click(button);
+        await user.click(button);
         expect(onClick).toHaveBeenCalled();
     });
 });

--- a/src/core/components/collapsible/collapsible.test.tsx
+++ b/src/core/components/collapsible/collapsible.test.tsx
@@ -71,15 +71,16 @@ describe('<Collapsible /> component', () => {
     });
 
     it('toggles opened/closed state when button is clicked', async () => {
+        const user = userEvent.setup();
         const buttonLabelOpened = 'Open';
         const buttonLabelClosed = 'Closed';
 
         render(createTestComponent({ buttonLabelOpened, buttonLabelClosed }));
 
         const button = screen.getByText('Closed');
-        await userEvent.click(button);
+        await user.click(button);
         expect(button.textContent).toBe('Open');
-        await userEvent.click(button);
+        await user.click(button);
         expect(button.textContent).toBe('Closed');
     });
 
@@ -95,34 +96,37 @@ describe('<Collapsible /> component', () => {
     });
 
     it('calls the onToggle callback with the new state', async () => {
+        const user = userEvent.setup();
         const onToggle = jest.fn();
         render(createTestComponent({ onToggle }));
 
         const button = screen.getByRole('button');
-        await userEvent.click(button);
+        await user.click(button);
         expect(onToggle).toHaveBeenCalledWith(true);
-        await userEvent.click(button);
+        await user.click(button);
         expect(onToggle).toHaveBeenCalledWith(false);
     });
 
     it('renders custom button labels', async () => {
+        const user = userEvent.setup();
         const buttonLabelOpened = 'Collapse';
         const buttonLabelClosed = 'Expand';
         render(createTestComponent({ buttonLabelOpened, buttonLabelClosed }));
 
         expect(screen.getByText('Expand')).toBeInTheDocument();
-        await userEvent.click(screen.getByText('Expand'));
+        await user.click(screen.getByText('Expand'));
         expect(screen.getByText('Collapse')).toBeInTheDocument();
     });
 
     it('handles absence of buttonVariant using default button styles', async () => {
+        const user = userEvent.setup();
         const buttonLabelOpened = 'Collapse';
         const buttonLabelClosed = 'Expand';
         render(createTestComponent({ buttonLabelOpened, buttonLabelClosed }));
 
         const button = screen.getByRole('button');
 
-        await userEvent.click(button);
+        await user.click(button);
         expect(button).toHaveTextContent('Collapse');
     });
 

--- a/src/core/components/dataList/dataListFilter/dataListFilter.test.tsx
+++ b/src/core/components/dataList/dataListFilter/dataListFilter.test.tsx
@@ -49,10 +49,11 @@ describe('<DataList.Filter /> component', () => {
     });
 
     it('calls the onSearchValueChange callback on search value change', async () => {
+        const user = userEvent.setup();
         const props = { onSearchValueChange: jest.fn() };
         const value = 't';
         render(createTestComponent({ props }));
-        await userEvent.type(screen.getByRole('searchbox'), value);
+        await user.type(screen.getByRole('searchbox'), value);
         expect(props.onSearchValueChange).toHaveBeenCalledWith(value);
     });
 
@@ -77,9 +78,10 @@ describe('<DataList.Filter /> component', () => {
     });
 
     it('calls the onSearchValueChange callback with undefined on clear icon click', async () => {
+        const user = userEvent.setup();
         const props = { searchValue: 'test', onSearchValueChange: jest.fn() };
         render(createTestComponent({ props }));
-        await userEvent.click(screen.getByTestId(IconType.CLOSE));
+        await user.click(screen.getByTestId(IconType.CLOSE));
         expect(props.onSearchValueChange).toHaveBeenCalledWith(undefined);
     });
 });

--- a/src/core/components/dataList/dataListFilter/dataListFilterSort.test.tsx
+++ b/src/core/components/dataList/dataListFilter/dataListFilterSort.test.tsx
@@ -54,12 +54,13 @@ describe('<DataListFilterSort /> component', () => {
     });
 
     it('renders the specified sort items on sort button click', async () => {
+        const user = userEvent.setup();
         const sortItems = [
             { value: 't1', label: 'Test 1', type: 'ASC' as const },
             { value: 't2', label: 'Test 2', type: 'ASC' as const },
         ];
         render(createTestComponent({ sortItems }));
-        await userEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
 
         expect(screen.getAllByRole('menuitem').length).toEqual(sortItems.length);
         expect(screen.getByRole('menuitem', { name: sortItems[0].label })).toBeInTheDocument();
@@ -67,14 +68,15 @@ describe('<DataListFilterSort /> component', () => {
     });
 
     it('calls the onSortChange callback with selected sort item value on sort item click', async () => {
+        const user = userEvent.setup();
         const onSortChange = jest.fn();
         const sortItems = [
             { value: 'value1', label: 'label1', type: 'ASC' as const },
             { value: 'value2', label: 'label2', type: 'ASC' as const },
         ];
         render(createTestComponent({ sortItems, onSortChange }));
-        await userEvent.click(screen.getByRole('button'));
-        await userEvent.click(screen.getByRole('menuitem', { name: sortItems[1].label }));
+        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('menuitem', { name: sortItems[1].label }));
         expect(onSortChange).toHaveBeenCalledWith(sortItems[1].value);
     });
 });

--- a/src/core/components/dataList/dataListPagination/dataListPagination.test.tsx
+++ b/src/core/components/dataList/dataListPagination/dataListPagination.test.tsx
@@ -71,6 +71,7 @@ describe('<DataList.Pagination /> component', () => {
     });
 
     it('calls handleLoadMore callback with next page to load on load-more button click', async () => {
+        const user = userEvent.setup();
         const context = {
             state: 'idle' as const,
             childrenItemCount: 50,
@@ -79,7 +80,7 @@ describe('<DataList.Pagination /> component', () => {
             itemsCount: 50,
         };
         render(createTestComponent({ context }));
-        await userEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
         expect(context.handleLoadMore).toHaveBeenCalledWith(context.currentPage + 1);
     });
 

--- a/src/core/components/dataList/dataListRoot/dataListRoot.test.tsx
+++ b/src/core/components/dataList/dataListRoot/dataListRoot.test.tsx
@@ -24,6 +24,7 @@ describe('<DataList.Root /> component', () => {
     });
 
     it('provides a function that increases the internal current page and triggers the onLoadMore callback', async () => {
+        const user = userEvent.setup();
         const onLoadMore = jest.fn();
         const ChildrenComponent = () => {
             const { currentPage, handleLoadMore } = useDataListContext();
@@ -41,7 +42,7 @@ describe('<DataList.Root /> component', () => {
             </DataListRoot>,
         );
 
-        await userEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
         expect(screen.getByText('1')).toBeInTheDocument();
         expect(onLoadMore).toHaveBeenCalled();
     });

--- a/src/core/components/dialogs/dialog/dialogHeader/dialogHeader.test.tsx
+++ b/src/core/components/dialogs/dialog/dialogHeader/dialogHeader.test.tsx
@@ -38,12 +38,13 @@ describe('<Dialog.Header/> component', () => {
     });
 
     it('calls onBackClick when the back button is clicked', async () => {
+        const user = userEvent.setup();
         const handleBackClick = jest.fn();
 
         render(createTestComponent({ showBackButton: true, onBackClick: handleBackClick }));
 
         const backIcon = screen.getByTestId(IconType.CHEVRON_LEFT);
-        await userEvent.click(backIcon);
+        await user.click(backIcon);
 
         expect(handleBackClick).toHaveBeenCalled();
     });

--- a/src/core/components/dialogs/dialogAlert/dialogAlertRoot/dialogAlertRoot.test.tsx
+++ b/src/core/components/dialogs/dialogAlert/dialogAlertRoot/dialogAlertRoot.test.tsx
@@ -28,11 +28,12 @@ describe('<DialogAlert.Root/> component', () => {
     });
 
     it('calls the given click handler when the action button is clicked', async () => {
+        const user = userEvent.setup();
         const handleActionBtnClick = jest.fn();
 
         render(createTestComponent({ open: true, children: <button onClick={handleActionBtnClick} /> }));
 
-        await userEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
 
         expect(handleActionBtnClick).toHaveBeenCalled();
     });

--- a/src/core/components/dropdown/dropdownContainer/dropdownContainer.test.tsx
+++ b/src/core/components/dropdown/dropdownContainer/dropdownContainer.test.tsx
@@ -47,22 +47,25 @@ describe('<Dropdown.Container /> component', () => {
     });
 
     it('correctly triggers the onOpenChange callback on dropdown trigger click', async () => {
+        const user = userEvent.setup();
         const onOpenChange = jest.fn();
         render(createTestComponent({ onOpenChange }));
-        await userEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
         expect(onOpenChange).toHaveBeenCalledWith(true);
     });
 
     it('correctly triggers the onOpenChange callback on dropdown item click', async () => {
+        const user = userEvent.setup();
         const onOpenChange = jest.fn();
         const children = [<DropdownItem key="first">First</DropdownItem>];
         render(createTestComponent({ onOpenChange, children }));
-        await userEvent.click(screen.getByRole('button'));
-        await userEvent.click(screen.getByRole('menuitem'));
+        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('menuitem'));
         expect(onOpenChange).toHaveBeenLastCalledWith(false);
     });
 
     it('renders the customTrigger instead of the default button when specified', async () => {
+        const user = userEvent.setup();
         const onOpenChange = jest.fn();
         const customTrigger = <button>test</button>;
         render(createTestComponent({ onOpenChange, customTrigger }));
@@ -70,17 +73,18 @@ describe('<Dropdown.Container /> component', () => {
         const trigger = screen.getByRole('button', { name: 'test' });
         expect(trigger).toBeInTheDocument();
 
-        await userEvent.click(trigger!);
+        await user.click(trigger!);
         expect(onOpenChange).toHaveBeenCalled();
     });
 
     it('prevents moving focus back to the trigger on menu close to be able to open dialogs on menu-item click', async () => {
+        const user = userEvent.setup();
         const children = <DropdownItem>item-label</DropdownItem>;
         render(createTestComponent({ children }));
         const trigger = screen.getByRole('button');
 
-        await userEvent.click(trigger);
-        await userEvent.click(screen.getByRole('menuitem'));
+        await user.click(trigger);
+        await user.click(screen.getByRole('menuitem'));
 
         expect(trigger).not.toHaveFocus();
     });

--- a/src/core/components/input/inputDate/inputDate.test.tsx
+++ b/src/core/components/input/inputDate/inputDate.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import * as Utils from '../../../utils';
 import { IconType } from '../../icon';
@@ -40,7 +41,8 @@ describe('<InputDate /> component', () => {
         expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
 
-    it('renders a button which opens the date picker on click', () => {
+    it('renders a button which opens the date picker on click', async () => {
+        const user = userEvent.setup();
         const showPicker = jest.fn();
         useRefMock.mockReturnValue({ current: { showPicker } });
         mergeRefMock.mockReturnValue(() => null);
@@ -50,7 +52,7 @@ describe('<InputDate /> component', () => {
         expect(calendarButton).toBeInTheDocument();
         expect(within(calendarButton).getByTestId(IconType.CALENDAR)).toBeInTheDocument();
 
-        fireEvent.click(calendarButton);
+        await user.click(calendarButton);
         expect(showPicker).toHaveBeenCalled();
     });
 });

--- a/src/core/components/input/inputFileAvatar/inputFileAvatar.test.tsx
+++ b/src/core/components/input/inputFileAvatar/inputFileAvatar.test.tsx
@@ -56,6 +56,7 @@ describe('<InputFileAvatar /> component', () => {
     });
 
     it('displays a preview and calls the onFileSelect callback when a valid file is selected', async () => {
+        const user = userEvent.setup();
         const label = 'test-label';
         const fileSrc = 'https://chucknorris.com/image.png';
         const file = new File(['(⌐□_□)'], fileSrc, { type: 'image/png' });
@@ -63,7 +64,7 @@ describe('<InputFileAvatar /> component', () => {
         createObjectURLMock.mockReturnValue(fileSrc);
 
         render(createTestComponent({ label, onFileSelect }));
-        await userEvent.upload(screen.getByLabelText(label), file);
+        await user.upload(screen.getByLabelText(label), file);
         const previewImg = await screen.findByRole<HTMLImageElement>('img');
 
         expect(previewImg).toBeInTheDocument();
@@ -72,21 +73,23 @@ describe('<InputFileAvatar /> component', () => {
     });
 
     it('clears the current file selection on close button click after an image has been selected', async () => {
+        const user = userEvent.setup();
         const label = 'test-label';
         const file = new File(['something'], 'test.png', { type: 'image/png' });
         createObjectURLMock.mockReturnValue('file-src');
 
         render(createTestComponent({ label }));
-        await userEvent.upload(screen.getByLabelText(label), file);
+        await user.upload(screen.getByLabelText(label), file);
         const cancelButton = await screen.findByRole('button');
         expect(cancelButton).toBeInTheDocument();
 
-        await userEvent.click(cancelButton);
+        await user.click(cancelButton);
         expect(screen.getByTestId(IconType.PLUS)).toBeInTheDocument();
         expect(screen.queryByRole('img')).not.toBeInTheDocument();
     });
 
     it('calls onFileError when file has incorrect dimensions', async () => {
+        const user = userEvent.setup();
         const originalWidth = global.Image.prototype.width;
         global.Image.prototype.width = 800;
 
@@ -96,7 +99,7 @@ describe('<InputFileAvatar /> component', () => {
         const minDimension = 1000;
 
         render(createTestComponent({ label, onFileError, minDimension }));
-        await userEvent.upload(screen.getByLabelText(label), file);
+        await user.upload(screen.getByLabelText(label), file);
         await waitFor(() => expect(onFileError).toHaveBeenCalledWith(InputFileAvatarError.WRONG_DIMENSION));
 
         global.Image.prototype.width = originalWidth;

--- a/src/core/components/input/inputNumber/inputNumber.test.tsx
+++ b/src/core/components/input/inputNumber/inputNumber.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { IconType } from '../../icon';
 import * as InputHooks from '../hooks';
 import { InputNumber, type IInputNumberProps } from './inputNumber';
@@ -47,10 +48,11 @@ describe('<InputNumber /> component', () => {
             useNumberMaskMock.mockReset();
         });
 
-        const testIncrementLogic = ({
+        const testIncrementLogic = async ({
             expectedValue,
             ...props
         }: Partial<IInputNumberProps> & { expectedValue: string }) => {
+            const user = userEvent.setup();
             const setValue = jest.fn();
             const hookResult = {
                 setValue,
@@ -62,39 +64,39 @@ describe('<InputNumber /> component', () => {
             render(createTestComponent({ ...props }));
 
             const [, incrementButton] = screen.getAllByRole<HTMLButtonElement>('button');
-            fireEvent.click(incrementButton);
+            await user.click(incrementButton);
 
             expect(setValue).toHaveBeenCalledWith(expectedValue);
         };
 
-        it('should increment by one (1) with default parameters', () => {
-            testIncrementLogic({ expectedValue: '1' });
+        it('should increment by one (1) with default parameters', async () => {
+            await testIncrementLogic({ expectedValue: '1' });
         });
 
-        it('should return the maximum when the newly generated value exceeds the maximum', () => {
+        it('should return the maximum when the newly generated value exceeds the maximum', async () => {
             const max = 5;
             const step = 2;
             const value = '4';
-            testIncrementLogic({ max, step, value, expectedValue: max.toString() });
+            await testIncrementLogic({ max, step, value, expectedValue: max.toString() });
         });
 
-        it('should increment by floating point value when the step is a float', () => {
+        it('should increment by floating point value when the step is a float', async () => {
             const value = '1';
             const step = 0.5;
-            testIncrementLogic({ step, value, expectedValue: (Number(value) + step).toString() });
+            await testIncrementLogic({ step, value, expectedValue: (Number(value) + step).toString() });
         });
 
-        it('should round down to the nearest multiple of the step before incrementing by the step value', () => {
+        it('should round down to the nearest multiple of the step before incrementing by the step value', async () => {
             const value = '1';
             const step = 0.3;
-            testIncrementLogic({ step, value, expectedValue: '1.2' });
+            await testIncrementLogic({ step, value, expectedValue: '1.2' });
         });
 
-        it('should increment to the minimum when no value is provided', () => {
+        it('should increment to the minimum when no value is provided', async () => {
             const step = 6;
             const min = 5;
             const max = 10;
-            testIncrementLogic({ step, min, max, expectedValue: min.toString() });
+            await testIncrementLogic({ step, min, max, expectedValue: min.toString() });
         });
     });
 
@@ -105,10 +107,11 @@ describe('<InputNumber /> component', () => {
             useNumberMaskMock.mockReset();
         });
 
-        const testDecrementLogic = ({
+        const testDecrementLogic = async ({
             expectedValue,
             ...props
         }: Partial<IInputNumberProps> & { expectedValue: string }) => {
+            const user = userEvent.setup();
             const setValue = jest.fn();
             const hookResult = {
                 setValue,
@@ -120,28 +123,28 @@ describe('<InputNumber /> component', () => {
             render(createTestComponent({ ...props }));
 
             const [decrementButton] = screen.getAllByRole<HTMLButtonElement>('button');
-            fireEvent.click(decrementButton);
+            await user.click(decrementButton);
 
             expect(setValue).toHaveBeenCalledWith(expectedValue);
         };
 
-        it('should decrement by step', () => {
+        it('should decrement by step', async () => {
             const value = '10';
             const step = 2;
             const expectedValue = (10 - 2).toString();
-            testDecrementLogic({ value, step, expectedValue });
+            await testDecrementLogic({ value, step, expectedValue });
         });
 
-        it('should decrement to the minimum when no value provided', () => {
+        it('should decrement to the minimum when no value provided', async () => {
             const step = 2;
             const min = 1;
-            testDecrementLogic({ step, min, expectedValue: min.toString() });
+            await testDecrementLogic({ step, min, expectedValue: min.toString() });
         });
 
-        it('should decrement to the closest multiple of the step smaller than the value', () => {
+        it('should decrement to the closest multiple of the step smaller than the value', async () => {
             const value = '10';
             const step = 3;
-            testDecrementLogic({ value, step, expectedValue: '9' });
+            await testDecrementLogic({ value, step, expectedValue: '9' });
         });
     });
 });

--- a/src/core/components/input/inputNumberMax/inputNumberMax.test.tsx
+++ b/src/core/components/input/inputNumberMax/inputNumberMax.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { createRef } from 'react';
 import * as InputHooks from '../hooks';
 import { InputNumberMax, type IInputNumberMaxProps } from './inputNumberMax';
@@ -30,16 +31,17 @@ describe('<InputNumberMax /> component', () => {
     it('renders an input with a max button', () => {
         render(createTestComponent());
         expect(screen.getByRole('textbox')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Max' })).toBeInTheDocument();
+        expect(screen.getByRole('button')).toBeInTheDocument();
     });
 
-    it('updates the mask value with the max property on max button click', () => {
+    it('updates the mask value with the max property on max button click', async () => {
+        const user = userEvent.setup();
         const max = 1_000_000;
         const setValue = jest.fn();
         const hookResult = { setValue } as unknown as InputHooks.IUseNumberMaskResult;
         useNumberMaskMock.mockReturnValue(hookResult);
         render(createTestComponent({ max }));
-        fireEvent.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('button'));
         expect(setValue).toHaveBeenCalledWith(max.toString());
     });
 

--- a/src/core/components/input/inputSearch/inputSearch.test.tsx
+++ b/src/core/components/input/inputSearch/inputSearch.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { IconType } from '../../icon';
 import { InputSearch, type IInputSearchProps } from './inputSearch';
 
@@ -9,7 +10,7 @@ describe('<InputSearch /> component', () => {
         return <InputSearch {...completeProps} />;
     };
 
-    it('renders a input search field with a search icon', () => {
+    it('renders an input search field with a search icon', () => {
         render(createTestComponent());
         expect(screen.getByRole('searchbox')).toBeInTheDocument();
         expect(screen.getByTestId(IconType.SEARCH)).toBeInTheDocument();
@@ -36,27 +37,31 @@ describe('<InputSearch /> component', () => {
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
-    it('correctly handles styles on focus and blur and calls the onBlur and onFocus props', () => {
+    it('correctly handles styles on focus and blur and calls the onBlur and onFocus props', async () => {
+        const user = userEvent.setup();
         const onFocus = jest.fn();
         const onBlur = jest.fn();
         render(createTestComponent({ onFocus, onBlur }));
+        const searchbox = screen.getByRole('searchbox');
         const searchIcon = screen.getByTestId(IconType.SEARCH);
 
-        fireEvent.focus(screen.getByRole('searchbox'));
+        await user.click(searchbox);
         expect(searchIcon.getAttribute('class')).toContain('text-neutral-600');
         expect(onFocus).toHaveBeenCalled();
 
-        fireEvent.blur(screen.getByRole('searchbox'));
+        await user.tab();
         expect(searchIcon.getAttribute('class')).not.toContain('text-neutral-600');
         expect(onBlur).toHaveBeenCalled();
     });
 
-    it('clears input value on clear icon click', () => {
+    it('clears input value on clear icon click', async () => {
+        const user = userEvent.setup();
         const initialValue = 'test';
         render(createTestComponent());
-        fireEvent.change(screen.getByRole('searchbox'), { target: { value: initialValue } });
-        expect(screen.getByRole<HTMLInputElement>('searchbox').value).toEqual(initialValue);
-        fireEvent.click(screen.getByRole('button'));
-        expect(screen.getByRole<HTMLInputElement>('searchbox').value).toEqual('');
+        const searchbox = screen.getByRole<HTMLInputElement>('searchbox');
+        await user.type(searchbox, initialValue);
+        expect(searchbox.value).toEqual(initialValue);
+        await user.click(screen.getByRole('button'));
+        expect(searchbox.value).toEqual('');
     });
 });

--- a/src/core/components/input/inputTime/inputTime.test.tsx
+++ b/src/core/components/input/inputTime/inputTime.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import * as Utils from '../../../utils';
 import { IconType } from '../../icon';
@@ -29,7 +30,8 @@ describe('<InputTime /> component', () => {
         expect(timeInput.type).toEqual('time');
     });
 
-    it('renders a button which opens the time picker on click', () => {
+    it('renders a button which opens the time picker on click', async () => {
+        const user = userEvent.setup();
         const showPicker = jest.fn();
         useRefMock.mockReturnValue({ current: { showPicker } });
         mergeRefMock.mockReturnValue(() => null);
@@ -40,7 +42,7 @@ describe('<InputTime /> component', () => {
         expect(timeButton).toBeInTheDocument();
         expect(within(timeButton).getByTestId(IconType.CLOCK)).toBeInTheDocument();
 
-        fireEvent.click(timeButton);
+        await user.click(timeButton);
         expect(showPicker).toHaveBeenCalled();
     });
 

--- a/src/core/components/link/link/link.test.tsx
+++ b/src/core/components/link/link/link.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Link, type ILinkProps } from '.';
 
 describe('<Link /> component', () => {
@@ -15,13 +16,14 @@ describe('<Link /> component', () => {
         expect(linkElement).toHaveAttribute('href', 'http://example.com');
     });
 
-    it('applies correct classes based on disabled prop', () => {
+    it('applies correct classes based on disabled prop', async () => {
+        const user = userEvent.setup();
         const handleClick = jest.fn();
         render(createTestComponent({ children: 'TEST', disabled: true, onClick: handleClick }));
 
         // eslint-disable-next-line testing-library/no-node-access
         const linkElement = screen.getByText('TEST').closest('a')!;
-        fireEvent.click(linkElement);
+        await user.click(linkElement);
 
         expect(linkElement).toHaveAttribute('aria-disabled', 'true');
         expect(linkElement).not.toHaveAttribute('href');

--- a/src/core/components/radioGroup/radio/radio.test.tsx
+++ b/src/core/components/radioGroup/radio/radio.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { RadioGroup } from '..';
 import { IconType } from '../../icon';
 import { Radio, type IRadioProps } from './radio';
@@ -9,7 +10,7 @@ describe('<Radio/> component', () => {
 
         return (
             <RadioGroup name="Test Group">
-                <Radio {...completeProps} />;
+                <Radio {...completeProps} />
             </RadioGroup>
         );
     };
@@ -35,12 +36,13 @@ describe('<Radio/> component', () => {
         expect(screen.getByRole('radio')).not.toBeChecked();
     });
 
-    it('renders the RADIO_SELECTED icon when checked', () => {
+    it('renders the RADIO_SELECTED icon when checked', async () => {
+        const user = userEvent.setup();
         render(createTestComponent());
 
         const radioButton = screen.getByRole('radio');
 
-        fireEvent.click(radioButton);
+        await user.click(radioButton);
         const checkedIcon = screen.getByTestId(IconType.RADIO_SELECTED);
 
         expect(checkedIcon).toBeVisible();

--- a/src/core/components/radioGroup/radioCard/radioCard.test.tsx
+++ b/src/core/components/radioGroup/radioCard/radioCard.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { RadioGroup } from '..';
 import { IconType } from '../../icon';
 import { RadioCard, type IRadioCardProps } from './radioCard';
@@ -45,12 +46,13 @@ describe('<RadioCard/> component', () => {
         expect(screen.getByRole('radio')).not.toBeChecked();
     });
 
-    it('renders the RADIO_SELECTED icon when checked', () => {
+    it('renders the RADIO_SELECTED icon when checked', async () => {
+        const user = userEvent.setup();
         render(createTestComponent());
 
         const radioButton = screen.getByRole('radio');
 
-        fireEvent.click(radioButton);
+        await user.click(radioButton);
         const checkedIcon = screen.getByTestId(IconType.RADIO_SELECTED);
 
         expect(checkedIcon).toBeVisible();

--- a/src/core/components/radioGroup/radioGroup/radioGroup.test.tsx
+++ b/src/core/components/radioGroup/radioGroup/radioGroup.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { RadioGroup, type IRadioGroupProps } from '..';
 import { Radio } from '../radio';
 
@@ -31,7 +32,7 @@ describe('<RadioGroup /> component', () => {
         });
     });
 
-    it('set the radio group value correctly', () => {
+    it('sets the radio group value correctly', () => {
         const value = '1';
         const children = [<Radio value={value} label="1" key={1} />, <Radio value="2" label="2" key={2} />];
 
@@ -41,14 +42,15 @@ describe('<RadioGroup /> component', () => {
         expect(inputRadioElement).toHaveValue(value);
     });
 
-    it('calls `onValueChange` when a radio button is clicked', () => {
+    it('calls `onValueChange` when a radio button is clicked', async () => {
+        const user = userEvent.setup();
         const handleValueChange = jest.fn();
         const value = '1';
         const children = [<Radio value={value} label="1" key={1} />];
 
         render(createTestComponent({ children, onValueChange: handleValueChange }));
 
-        fireEvent.click(screen.getByRole('radio'));
+        await user.click(screen.getByRole('radio'));
         expect(handleValueChange).toHaveBeenCalledWith(value);
     });
 });

--- a/src/core/components/switch/switch.test.tsx
+++ b/src/core/components/switch/switch.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Switch, type ISwitchProps } from './switch';
 
 describe('<Switch /> component', () => {
@@ -37,22 +38,24 @@ describe('<Switch /> component', () => {
         expect(screen.getByRole('switch')).toHaveAttribute('id');
     });
 
-    it('invokes callback on state change and toggles state value', () => {
+    it('invokes callback on state change and toggles state value', async () => {
+        const user = userEvent.setup();
         const mockCallback = jest.fn();
         render(createTestComponent({ checked: true, onCheckedChanged: mockCallback }));
 
         const switchElement = screen.getByRole('switch');
-        fireEvent.click(switchElement);
+        await user.click(switchElement);
 
         expect(mockCallback).toHaveBeenCalledWith(false);
     });
 
-    it('renders as disabled when disabled prop is true', () => {
+    it('renders as disabled when disabled prop is true', async () => {
+        const user = userEvent.setup();
         const mockCallback = jest.fn();
         render(createTestComponent({ disabled: true, onCheckedChanged: mockCallback }));
 
         const switchElement = screen.getByRole('switch');
-        fireEvent.click(switchElement);
+        await user.click(switchElement);
 
         expect(switchElement).toBeDisabled();
         expect(mockCallback).not.toHaveBeenCalled();

--- a/src/core/components/textAreas/textAreaRichText/textAreaRichText.test.tsx
+++ b/src/core/components/textAreas/textAreaRichText/textAreaRichText.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import ReactDOM from 'react-dom';
 import { IconType } from '../../icon';
 import { TextAreaRichText, type ITextAreaRichTextProps } from './textAreaRichText';
@@ -36,12 +37,14 @@ describe('<TextAreaRichText /> component', () => {
     it('disables the textbox when the disabled property is set to true', async () => {
         const disabled = true;
         render(createTestComponent({ disabled }));
-        expect((await screen.findByRole('textbox')).getAttribute('contenteditable')).toEqual('false');
+        const textbox = await screen.findByRole('textbox');
+        expect(textbox.getAttribute('contenteditable')).toEqual('false');
     });
 
     it('generates a random id for the textbox when the id property is not set', async () => {
         render(createTestComponent());
-        expect((await screen.findByRole('textbox')).getAttribute('aria-labelledby')).toBeDefined();
+        const textbox = await screen.findByRole('textbox');
+        expect(textbox.getAttribute('aria-labelledby')).toBeDefined();
     });
 
     it('calls the onChange property on input change', async () => {
@@ -51,17 +54,19 @@ describe('<TextAreaRichText /> component', () => {
         expect(onChange).toHaveBeenCalled();
     });
 
-    it('renders the textarea as a React portal on expand action click', () => {
+    it('renders the textarea as a React portal on expand action click', async () => {
+        const user = userEvent.setup();
         render(createTestComponent());
-        fireEvent.click(screen.getByTestId(IconType.EXPAND));
+        await user.click(screen.getByTestId(IconType.EXPAND));
         expect(createPortalMock).toHaveBeenCalled();
         expect(document.body.style.overflow).toEqual('hidden');
     });
 
-    it('reset the expanded state on ESC key down', () => {
+    it('resets the expanded state on ESC key down', async () => {
+        const user = userEvent.setup();
         render(createTestComponent());
-        fireEvent.click(screen.getByTestId(IconType.EXPAND));
-        fireEvent.keyDown(window, { key: 'Escape' });
+        await user.click(screen.getByTestId(IconType.EXPAND));
+        await user.keyboard('{Escape}');
         expect(document.body.style.overflow).toEqual('auto');
     });
 });

--- a/src/core/components/toggles/toggle/toggle.test.tsx
+++ b/src/core/components/toggles/toggle/toggle.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { ToggleGroup } from '../toggleGroup';
 import { Toggle, type IToggleProps } from './toggle';
 
@@ -29,9 +30,10 @@ describe('<Toggle /> component', () => {
         expect(screen.getByRole('radio')).toBeDisabled();
     });
 
-    it('renders the toggle as active when clicked', () => {
+    it('renders the toggle as active when clicked', async () => {
+        const user = userEvent.setup();
         render(createTestComponent());
-        fireEvent.click(screen.getByRole('radio'));
+        await user.click(screen.getByRole('radio'));
         expect(screen.getByRole('radio')).toBeChecked();
     });
 });

--- a/src/core/components/toggles/toggleGroup/toggleGroup.test.tsx
+++ b/src/core/components/toggles/toggleGroup/toggleGroup.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Toggle } from '../toggle';
 import { ToggleGroup, type IToggleGroupBaseProps, type IToggleGroupProps } from './toggleGroup';
 
@@ -22,22 +23,24 @@ describe('<ToggleGroup /> component', () => {
         expect(screen.getAllByRole('radio')).toHaveLength(children.length);
     });
 
-    it('correctly updates the active value on toggle click', () => {
+    it('correctly updates the active value on toggle click', async () => {
+        const user = userEvent.setup();
         const onChange = jest.fn();
         const value = 'test';
         const children = [<Toggle key={value} value={value} label={value} />];
         const { rerender } = render(createTestComponent({ onChange, children }));
 
-        fireEvent.click(screen.getByRole('radio'));
+        await user.click(screen.getByRole('radio'));
         expect(onChange).toHaveBeenCalledWith(value);
 
         rerender(createTestComponent({ value, onChange, children }));
 
-        fireEvent.click(screen.getByRole('radio'));
+        await user.click(screen.getByRole('radio'));
         expect(onChange).toHaveBeenCalledWith('');
     });
 
-    it('correctly updates the active values on toggle click on multi-select variant', () => {
+    it('correctly updates the active values on toggle click on multi-select variant', async () => {
+        const user = userEvent.setup();
         const onChange = jest.fn();
         const isMultiSelect = true;
         const firstValue = 'first';
@@ -48,13 +51,13 @@ describe('<ToggleGroup /> component', () => {
         ];
         const { rerender } = render(createTestComponent({ onChange, children, isMultiSelect }));
 
-        fireEvent.click(screen.getByRole('button', { name: firstValue }));
+        await user.click(screen.getByRole('button', { name: firstValue }));
         const newValue = [firstValue];
         expect(onChange).toHaveBeenCalledWith(newValue);
 
         rerender(createTestComponent({ value: newValue, onChange, children, isMultiSelect }));
 
-        fireEvent.click(screen.getByRole('button', { name: secondValue }));
+        await user.click(screen.getByRole('button', { name: secondValue }));
         expect(onChange).toHaveBeenCalledWith([...newValue, secondValue]);
     });
 });

--- a/src/core/components/tooltip/tooltip.test.tsx
+++ b/src/core/components/tooltip/tooltip.test.tsx
@@ -34,12 +34,13 @@ describe('<Tooltip/> component', () => {
     });
 
     it(`renders the tooltip content when the trigger is hovered on`, async () => {
+        const user = userEvent.setup();
         const trigger = 'test-trigger';
         const content = 'test-content';
 
         render(createTestComponent({ content, children: trigger }));
 
-        await userEvent.hover(screen.getByText(trigger));
+        await user.hover(screen.getByText(trigger));
         const tooltip = await screen.findByRole('tooltip');
 
         expect(tooltip).toBeInTheDocument();
@@ -47,12 +48,13 @@ describe('<Tooltip/> component', () => {
     });
 
     it('calls onOpenChange with true on trigger hover', async () => {
+        const user = userEvent.setup();
         const handleOpenChange = jest.fn();
         const trigger = 'test-trigger';
 
         render(createTestComponent({ children: trigger, onOpenChange: handleOpenChange }));
 
-        await userEvent.hover(screen.getByText(trigger));
+        await user.hover(screen.getByText(trigger));
         await waitFor(() => expect(handleOpenChange).toHaveBeenCalledWith(true));
     });
 });

--- a/src/modules/components/address/addressInput/addressInput.test.tsx
+++ b/src/modules/components/address/addressInput/addressInput.test.tsx
@@ -68,14 +68,16 @@ describe('<AddressInput /> component', () => {
     });
 
     it('calls the onChange property on input field change', async () => {
+        const user = userEvent.setup();
         const input = '0';
         const onChange = jest.fn();
         render(createTestComponent({ onChange }));
-        await userEvent.type(screen.getByRole('textbox'), input);
+        await user.type(screen.getByRole('textbox'), input);
         expect(onChange).toHaveBeenCalledWith(input);
     });
 
     it('renders a paste button to read and paste the user clipboard into the input field', async () => {
+        const user = userEvent.setup();
         const userClipboard = 'vitalik.eth';
         pasteMock.mockResolvedValue(userClipboard);
         const onChange = jest.fn();
@@ -84,7 +86,7 @@ describe('<AddressInput /> component', () => {
         const pasteButton = screen.getByRole('button', { name: 'Paste' });
         expect(pasteButton).toBeInTheDocument();
 
-        await userEvent.click(pasteButton);
+        await user.click(pasteButton);
         expect(onChange).toHaveBeenCalledWith(userClipboard);
     });
 
@@ -95,6 +97,7 @@ describe('<AddressInput /> component', () => {
     });
 
     it('renders a clear button to clear current input value when input is focused', async () => {
+        const user = userEvent.setup();
         const value = 'test-value';
         const onChange = jest.fn();
         render(createTestComponent({ value, onChange }));
@@ -103,16 +106,17 @@ describe('<AddressInput /> component', () => {
         const clearButton = screen.getByRole('button', { name: 'Clear' });
         expect(clearButton).toBeInTheDocument();
 
-        await userEvent.click(clearButton);
+        await user.click(clearButton);
         expect(onChange).toHaveBeenCalledWith(undefined);
     });
 
     it('renders a copy button to copy current input value when current value is a valid address', async () => {
+        const user = userEvent.setup();
         const value = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
         render(createTestComponent({ value }));
         const copyButton = screen.getAllByRole('button').find((button) => within(button).findByTestId(IconType.COPY));
         expect(copyButton).toBeInTheDocument();
-        await userEvent.click(copyButton!);
+        await user.click(copyButton!);
         expect(copyMock).toHaveBeenCalledWith(value);
     });
 
@@ -136,6 +140,7 @@ describe('<AddressInput /> component', () => {
     });
 
     it('displays a button to display the ENS value linked to the address input when address has ENS linked', async () => {
+        const user = userEvent.setup();
         const ensValue = 'vitalik.eth';
         const value = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
         const onChange = jest.fn();
@@ -145,11 +150,12 @@ describe('<AddressInput /> component', () => {
         const ensButton = screen.getByRole('button', { name: 'ENS' });
         expect(ensButton).toBeInTheDocument();
 
-        await userEvent.click(ensButton);
+        await user.click(ensButton);
         expect(onChange).toHaveBeenCalledWith(ensValue);
     });
 
     it('displays a button to display the address value linked to the ENS input when ENS is linked to an address', async () => {
+        const user = userEvent.setup();
         const addressValue: Address = '0xeefB13C7D42eFCc655E528dA6d6F7bBcf9A2251d';
         const value = 'cdixon.eth';
         const onChange = jest.fn();
@@ -159,7 +165,7 @@ describe('<AddressInput /> component', () => {
         const addressButton = screen.getByRole('button', { name: '0x …' });
         expect(addressButton).toBeInTheDocument();
 
-        await userEvent.click(addressButton);
+        await user.click(addressButton);
         expect(onChange).toHaveBeenCalledWith(addressValue);
     });
 


### PR DESCRIPTION
## Description

Migrate to using userEvent instead of fireEvent for unit tests. The only test case which still relies on fireEvent is "calls the onChange property on input change."

Task: [APP-2855](https://aragonassociation.atlassian.net/browse/APP-2855)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [ ] I have tested my code on the test network.


[APP-2855]: https://aragonassociation.atlassian.net/browse/APP-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ