### PR TITLE
fix: Revert to using react-docgen-typescript for higher docs fidelity 

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -40,6 +40,7 @@ const config: StorybookConfig = {
     },
 
     typescript: {
+        // Use react-docgen-typescript to generate args descriptions from component props comments
         reactDocgen: 'react-docgen-typescript',
     },
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -39,6 +39,10 @@ const config: StorybookConfig = {
         options: {},
     },
 
+    typescript: {
+        reactDocgen: 'react-docgen-typescript',
+    },
+
     webpackFinal: (webpackConfig) => {
         // Remove any svg loader already set and use @svgr/webpack to load svgs on Storybook
         const svgWebpackRule = webpackConfig.module?.rules?.find((rule) => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Remove Radix props dependency
 -   Update minor and patch Github action dependencies
 -   Update minor and patch NPM dependencies
--   Revert to using 
+-   Revert to using `react-docgen-typescript` for Storybook documentation generation
 
 ## [1.0.34] - 2024-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Remove Radix props dependency
 -   Update minor and patch Github action dependencies
 -   Update minor and patch NPM dependencies
+-   Revert to using 
 
 ## [1.0.34] - 2024-06-21
 


### PR DESCRIPTION
## Description

Revert to using `react-docgen-typescript` to generate args description from prop comments.

## Type of change

<!--- Please delete options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [ ] I have tested my code on the test network.
