### PR TITLE
fix: update required params for useBlockExplorer hook, exports types for formatting dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 -   Reduce the use of controlled components in stories to improve code visibility in Storybook
+-   Export `DateFormat` and additional types for handling dates with the `FormatterUtils`
+-   Update required parameters of `useBlockExplorer` hook, implement enum for chain entity types
 
 ## [1.0.35] - 2024-06-28
 

--- a/src/core/utils/formatterUtils/index.ts
+++ b/src/core/utils/formatterUtils/index.ts
@@ -1,2 +1,9 @@
-export { formatterUtils, type IFormatNumberOptions, type IFormatDateOptions } from './formatterUtils';
-export { NumberFormat, numberFormats, DateFormat, dateFormats, type INumberFormat, type IDateFormat } from './formatterUtilsDefinitions';
+export { formatterUtils, type IFormatDateOptions, type IFormatNumberOptions } from './formatterUtils';
+export {
+    DateFormat,
+    NumberFormat,
+    dateFormats,
+    numberFormats,
+    type IDateFormat,
+    type INumberFormat,
+} from './formatterUtilsDefinitions';

--- a/src/core/utils/formatterUtils/index.ts
+++ b/src/core/utils/formatterUtils/index.ts
@@ -1,2 +1,2 @@
-export { formatterUtils, type IFormatNumberOptions } from './formatterUtils';
-export { NumberFormat, numberFormats, type INumberFormat } from './formatterUtilsDefinitions';
+export { formatterUtils, type IFormatNumberOptions, type IFormatDateOptions } from './formatterUtils';
+export { NumberFormat, numberFormats, DateFormat, dateFormats, type INumberFormat, type IDateFormat } from './formatterUtilsDefinitions';

--- a/src/modules/components/address/addressInput/addressInput.tsx
+++ b/src/modules/components/address/addressInput/addressInput.tsx
@@ -15,7 +15,7 @@ import {
     useInputProps,
     type IInputComponentProps,
 } from '../../../../core';
-import { useBlockExplorer, ChainEntityType } from '../../../hooks';
+import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import type { IWeb3ComponentProps } from '../../../types';
 import { addressUtils, ensUtils } from '../../../utils';
 import { MemberAvatar } from '../../member';

--- a/src/modules/components/address/addressInput/addressInput.tsx
+++ b/src/modules/components/address/addressInput/addressInput.tsx
@@ -15,7 +15,7 @@ import {
     useInputProps,
     type IInputComponentProps,
 } from '../../../../core';
-import { useBlockExplorer } from '../../../hooks';
+import { useBlockExplorer, ChainEntityType } from '../../../hooks';
 import type { IWeb3ComponentProps } from '../../../types';
 import { addressUtils, ensUtils } from '../../../utils';
 import { MemberAvatar } from '../../member';
@@ -68,7 +68,7 @@ export const AddressInput = forwardRef<HTMLTextAreaElement, IAddressInputProps>(
     const { getChainEntityUrl } = useBlockExplorer();
 
     const addressUrl = getChainEntityUrl({
-        type: 'address',
+        type: ChainEntityType.ADDRESS,
         chainId: processedChainId,
         id: value,
     });

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { Avatar, AvatarIcon, IconType, LinkBase, NumberFormat, formatterUtils } from '../../../../core';
-import { useBlockExplorer } from '../../../hooks';
+import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../types';
 import { AssetTransferAddress } from './assetTransferAddress';
 
@@ -87,7 +87,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                     participant={sender}
                     addressUrl={getChainEntityUrl({
                         chainId,
-                        type: 'address',
+                        type: ChainEntityType.ADDRESS,
                         id: sender.address,
                     })}
                 />
@@ -105,13 +105,13 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                     participant={recipient}
                     addressUrl={getChainEntityUrl({
                         chainId,
-                        type: 'address',
+                        type: ChainEntityType.ADDRESS,
                         id: recipient.address,
                     })}
                 />
             </div>
             <LinkBase
-                href={getChainEntityUrl({ chainId, type: 'tx', id: hash })}
+                href={getChainEntityUrl({ chainId, type: ChainEntityType.TRANSACTION, id: hash })}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={assetTransferClassNames}

--- a/src/modules/hooks/useBlockExplorer/index.ts
+++ b/src/modules/hooks/useBlockExplorer/index.ts
@@ -1,1 +1,1 @@
-export { ChainEntityType, useBlockExplorer, type IChainEntity } from './useBlockExplorer';
+export { ChainEntityType, useBlockExplorer, type IGetChainEntityUrlParams } from './useBlockExplorer';

--- a/src/modules/hooks/useBlockExplorer/index.ts
+++ b/src/modules/hooks/useBlockExplorer/index.ts
@@ -1,1 +1,1 @@
-export * from './useBlockExplorer';
+export { ChainEntityType, useBlockExplorer, type IChainEntity } from './useBlockExplorer';

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
@@ -17,9 +17,9 @@ describe('useBlockExplorer hook', () => {
         expect(result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, chainId: 1, id: '0x123' })).toEqual(
             'https://etherscan.io/address/0x123',
         );
-        expect(result.current.getChainEntityUrl({ type: ChainEntityType.TRANSACTION, id: '0xabc', chainId: 137 })).toEqual(
-            'https://polygonscan.com/tx/0xabc',
-        );
+        expect(
+            result.current.getChainEntityUrl({ type: ChainEntityType.TRANSACTION, id: '0xabc', chainId: 137 }),
+        ).toEqual('https://polygonscan.com/tx/0xabc');
     });
 
     it('throws an error when block explorer URL is missing', () => {
@@ -27,9 +27,9 @@ describe('useBlockExplorer hook', () => {
         useChainsSpy.mockReturnValue([chainWithoutBlockExplorer]);
 
         const { result } = renderHook(() => useBlockExplorer());
-        expect(() => result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, chainId: 1, id: '0x123' })).toThrow(
-            'useBlockExplorer: Block explorer URL not found for chain with id 1',
-        );
+        expect(() =>
+            result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, chainId: 1, id: '0x123' }),
+        ).toThrow('useBlockExplorer: Block explorer URL not found for chain with id 1');
     });
 
     it('uses the first chain set on the wagmi provider when chainId property is not set', () => {

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import * as wagmi from 'wagmi';
 import { mainnet, polygon } from 'wagmi/chains';
-import { useBlockExplorer } from './useBlockExplorer';
+import { ChainEntityType, useBlockExplorer } from './useBlockExplorer';
 
 describe('useBlockExplorer hook', () => {
     const useChainsSpy = jest.spyOn(wagmi, 'useChains');
@@ -14,10 +14,10 @@ describe('useBlockExplorer hook', () => {
         useChainsSpy.mockReturnValue([mainnet, polygon]);
 
         const { result } = renderHook(() => useBlockExplorer());
-        expect(result.current.getChainEntityUrl({ type: 'address', chainId: 1, id: '0x123' })).toEqual(
+        expect(result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, chainId: 1, id: '0x123' })).toEqual(
             'https://etherscan.io/address/0x123',
         );
-        expect(result.current.getChainEntityUrl({ type: 'tx', id: '0xabc', chainId: 137 })).toEqual(
+        expect(result.current.getChainEntityUrl({ type: ChainEntityType.TRANSACTION, id: '0xabc', chainId: 137 })).toEqual(
             'https://polygonscan.com/tx/0xabc',
         );
     });
@@ -27,7 +27,7 @@ describe('useBlockExplorer hook', () => {
         useChainsSpy.mockReturnValue([chainWithoutBlockExplorer]);
 
         const { result } = renderHook(() => useBlockExplorer());
-        expect(() => result.current.getChainEntityUrl({ type: 'address', chainId: 1, id: '0x123' })).toThrow(
+        expect(() => result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, chainId: 1, id: '0x123' })).toThrow(
             'useBlockExplorer: Block explorer URL not found for chain with id 1',
         );
     });
@@ -36,14 +36,14 @@ describe('useBlockExplorer hook', () => {
         useChainsSpy.mockReturnValue([mainnet, polygon]);
 
         const { result } = renderHook(() => useBlockExplorer());
-        expect(result.current.getChainEntityUrl({ type: 'address', id: '0x123' })).toEqual(
+        expect(result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, id: '0x123' })).toEqual(
             'https://etherscan.io/address/0x123',
         );
     });
 
     it('uses the first chain passed as parameters when chainId is not defined', () => {
         const { result } = renderHook(() => useBlockExplorer({ chains: [polygon, mainnet] }));
-        expect(result.current.getChainEntityUrl({ type: 'address', id: '0x123' })).toEqual(
+        expect(result.current.getChainEntityUrl({ type: ChainEntityType.ADDRESS, id: '0x123' })).toEqual(
             'https://polygonscan.com/address/0x123',
         );
     });

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
@@ -7,7 +7,7 @@ export enum ChainEntityType {
     TOKEN = 'token',
 }
 
-export interface IChainEntity {
+export interface IGetChainEntityUrlParams {
     /**
      * The type of the chain entity (address, tx, token)
      */
@@ -27,7 +27,7 @@ export const useBlockExplorer = (wagmiConfig?: Pick<Config, 'chains'>) => {
     const chains = wagmiConfig?.chains ?? globalChains;
 
     const getChainEntityUrl = useCallback(
-        ({ type, chainId, id }: IChainEntity) => {
+        ({ type, chainId, id }: IGetChainEntityUrlParams) => {
             const chain = chainId ? chains.find((chain) => chain.id === chainId) : chains[0];
             const baseUrl = chain?.blockExplorers?.default?.url;
             if (!baseUrl) {

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
@@ -4,8 +4,8 @@ import { useChains, type Config } from 'wagmi';
 export enum ChainEntityType {
     ADDRESS = 'address',
     TRANSACTION = 'tx',
-    TOKEN = 'token'
-} 
+    TOKEN = 'token',
+}
 
 interface IChainEntity {
     /**

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
@@ -7,7 +7,7 @@ export enum ChainEntityType {
     TOKEN = 'token',
 }
 
-interface IChainEntity {
+export interface IChainEntity {
     /**
      * The type of the chain entity (address, tx, token)
      */

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.ts
@@ -1,7 +1,11 @@
 import { useCallback } from 'react';
 import { useChains, type Config } from 'wagmi';
 
-type ChainEntityType = 'address' | 'tx' | 'token';
+export enum ChainEntityType {
+    ADDRESS = 'address',
+    TRANSACTION = 'tx',
+    TOKEN = 'token'
+} 
 
 interface IChainEntity {
     /**
@@ -15,7 +19,7 @@ interface IChainEntity {
     /**
      * The ID of the entity (e.g. tx hash for a tx)
      */
-    id: string;
+    id?: string;
 }
 
 export const useBlockExplorer = (wagmiConfig?: Pick<Config, 'chains'>) => {


### PR DESCRIPTION
## Description

Make params for useBlockExplorer hook optional to handle DAO query requirements
use enum for more secure type enforcement of link "types" in construction
export DateFormat and other usages for DateFormatter util

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
