### PR TITLE
fix: Fix undefined date case on ProposalDataListItem module component, fix DURATION date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Bump `ws` from 7.5.9 to 7.5.10
 -   Update minor and patch NPM dependencies
 
+### Fixed
+
+-   Update `ProposalDataListItem` module component to avoid showing `null` when date property is not defined
+-   Fix `DURATION` date format to use the date locale set on the formatter
+
 ## [1.0.39] - 2024-07-16
 
 ### Changed

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -7,16 +7,30 @@ import { DateFormat, NumberFormat } from './formatterUtilsDefinitions';
 
 describe('formatter utils', () => {
     const originalNow = Settings.now;
+    const originalDateLocale = formatterUtils.dateLocale;
+    const originalNumberLocale = formatterUtils.numberLocale;
 
     afterEach(() => {
         Settings.now = originalNow;
         Settings.defaultZone = 'utc';
+        formatterUtils.dateLocale = originalDateLocale;
+        formatterUtils.numberLocale = originalNumberLocale;
     });
+
+    const setTime = (now?: string) => {
+        Settings.now = () => (now != null ? new Date(now) : new Date()).valueOf();
+    };
+
+    const setLocale = (locales: { number?: string; date?: string }) => {
+        formatterUtils.dateLocale = locales.date ?? originalDateLocale;
+        formatterUtils.numberLocale = locales.number ?? originalNumberLocale;
+    };
 
     describe('number formatting', () => {
         describe('generic amounts', () => {
             test.each([
                 { value: -1234, result: '-1,234' },
+                { value: -1234, result: '-1.234', locale: 'it' },
                 { value: -123, result: '-123' },
                 { value: 0, result: '0' },
                 { value: 123, result: '123' },
@@ -27,7 +41,8 @@ describe('formatter utils', () => {
                 { value: 1234567890, result: '1,234,567,890' },
                 { value: 1234567890123, result: '1,234,567,890,123' },
                 { value: 1234567890123456, result: '1,234,567,890,123,456' },
-            ])('formats $value as $result using long format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.GENERIC_LONG, ...options })).toEqual(
                     result,
                 );
@@ -35,6 +50,7 @@ describe('formatter utils', () => {
 
             test.each([
                 { value: -1234, result: '-1.23K' },
+                { value: -1234, result: '-1,23K', locale: 'it' },
                 { value: -123, result: '-123' },
                 { value: 0, result: '0' },
                 { value: 123, result: '123' },
@@ -45,7 +61,8 @@ describe('formatter utils', () => {
                 { value: 1234567890, result: '1.23B' },
                 { value: 1234567890123, result: '1.23T' },
                 { value: 1234567890123456, result: '1.23 x 10^15' },
-            ])('formats $value as $result using short format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using short format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.GENERIC_SHORT, ...options })).toEqual(
                     result,
                 );
@@ -55,6 +72,7 @@ describe('formatter utils', () => {
         describe('fiat total amounts', () => {
             test.each([
                 { value: -1234.56789, result: '-$1,234.57' },
+                { value: -1234.56789, result: '-1.234,57 USD', locale: 'it' },
                 { value: -0.012345678, result: '-$0.01' },
                 { value: -0.0012345678, result: '-$0.001' },
                 { value: 0, result: '$0.00' },
@@ -70,7 +88,8 @@ describe('formatter utils', () => {
                 { value: 1234567890.12345, result: '$1,234,567,890.12' },
                 { value: 1234567890123.45678, result: '$1,234,567,890,123.46' },
                 { value: 1234567890123456.78901, result: '$1,234,567,890,123,456.80' },
-            ])('formats $value as $result using long format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(
                     formatterUtils.formatNumber(value, { format: NumberFormat.FIAT_TOTAL_LONG, ...options }),
                 ).toEqual(result);
@@ -101,6 +120,7 @@ describe('formatter utils', () => {
         describe('token amounts', () => {
             test.each([
                 { value: -1234.5678, result: '-1,234.5678' },
+                { value: -1234.5678, result: '-1.234,5678', locale: 'it' },
                 { value: -0.0123456789012345678, result: '-0.012345678901234568' },
                 { value: 0, result: '0' },
                 { value: 0.0012, result: '0.0012' },
@@ -115,7 +135,8 @@ describe('formatter utils', () => {
                 { value: 1234567890.1234, result: '1,234,567,890.1234' },
                 { value: 1234567890123.4567, result: '1,234,567,890,123.4568' },
                 { value: 1234567890123456.789, result: '1,234,567,890,123,456.8' },
-            ])('formats $value as $result using long format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(
                     formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_LONG, ...options }),
                 ).toEqual(result);
@@ -123,6 +144,7 @@ describe('formatter utils', () => {
 
             test.each([
                 { value: -1234, result: '-1.23K' },
+                { value: -1234, result: '-1,23K', locale: 'it' },
                 { value: -0.0012, result: '-0.001' },
                 { value: 0, result: '0' },
                 { value: 0.0012, result: '0.001' },
@@ -135,7 +157,8 @@ describe('formatter utils', () => {
                 { value: 1234567890.1234, result: '1.23B' },
                 { value: 1234567890123.4567, result: '1.23T' },
                 { value: 1234567890123456.789, result: '1.23 x 10^15' },
-            ])('formats $value as $result using short format', ({ value, result }) => {
+            ])('formats $value as $result using short format', ({ value, result, locale }) => {
+                setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_SHORT })).toEqual(result);
             });
         });
@@ -143,6 +166,7 @@ describe('formatter utils', () => {
         describe('token prices', () => {
             test.each([
                 { value: -1234.56789, result: '-$1,234.57' },
+                { value: -1234.56789, result: '-1.234,57 USD', locale: 'it' },
                 { value: -0.0012345678, result: '-$0.001235' },
                 { value: 0, result: 'Unknown' },
                 { value: 0.0012345678, result: '$0.001235' },
@@ -156,7 +180,8 @@ describe('formatter utils', () => {
                 { value: 1234567890.12345, result: '$1,234,567,890.12' },
                 { value: 1234567890123.45678, result: '$1,234,567,890,123.46' },
                 { value: 1234567890123456.78901, result: '$1,234,567,890,123,456.80' },
-            ])('formats $value as $result using token format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using token format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_PRICE, ...options })).toEqual(
                     result,
                 );
@@ -166,6 +191,7 @@ describe('formatter utils', () => {
         describe('percentages', () => {
             test.each([
                 { value: -1, result: '-100.00%' },
+                { value: -1, result: '-100,00%', locale: 'it' },
                 { value: -0.999001, result: '-99.90%' },
                 { value: -0.00012345, result: '-0.01%' },
                 { value: 0, result: '0.00%' },
@@ -179,7 +205,8 @@ describe('formatter utils', () => {
                 { value: 0.9985, result: '99.85%' },
                 { value: 0.999001, result: '99.90%' },
                 { value: 1, result: '100.00%' },
-            ])('formats $value as $result using long format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(
                     formatterUtils.formatNumber(value, { format: NumberFormat.PERCENTAGE_LONG, ...options }),
                 ).toEqual(result);
@@ -187,6 +214,7 @@ describe('formatter utils', () => {
 
             test.each([
                 { value: -0.999001, result: '-99.9%' },
+                { value: -0.999001, result: '-99,9%', locale: 'it' },
                 { value: -0.12345, result: '-12.3%' },
                 { value: -0.00012345, result: '-0.01%' },
                 { value: 0, result: '0%' },
@@ -201,7 +229,8 @@ describe('formatter utils', () => {
                 { value: 0.999001, result: '99.9%' },
                 { value: 0.999001, result: '+99.9%', withSign: true },
                 { value: 1, result: '100%' },
-            ])('formats $value as $result using short format', ({ value, result, ...options }) => {
+            ])('formats $value as $result using short format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
                 expect(
                     formatterUtils.formatNumber(value, { format: NumberFormat.PERCENTAGE_SHORT, ...options }),
                 ).toEqual(result);
@@ -210,10 +239,6 @@ describe('formatter utils', () => {
     });
 
     describe('date formatting', () => {
-        const setTime = (now?: string) => {
-            Settings.now = () => (now != null ? new Date(now) : new Date()).valueOf();
-        };
-
         describe('date parsing', () => {
             it('supports dates in DateTime format', () => {
                 const date = DateTime.fromISO('2016-05-25T09:08:34.123');
@@ -244,20 +269,28 @@ describe('formatter utils', () => {
         describe('YEAR_MONTH_DAY_TIME format', () => {
             test.each([
                 { value: '2009-01-02T10:10:41', result: 'January 2, 2009 at 10:10' },
+                { value: '2009-01-02T10:10:41', result: '2 gennaio 2009 alle ore 10:10', locale: 'it' },
                 { value: '2024-10-23T15:33:12', result: 'October 23, 2024 at 15:33' },
                 { value: '2024-10-23T15:10:00', result: 'today at 15:10', now: '2024-10-23T15:33:12' },
                 { value: '2024-10-22T00:10:12', result: 'yesterday at 00:10', now: '2024-10-23T15:33:12' },
                 { value: '2024-10-24T23:59:59', result: 'tomorrow at 23:59', now: '2024-10-23T15:33:12' },
                 { value: '2024-10-25T00:00:00', result: 'October 25, 2024 at 00:00', now: '2024-10-23T15:33:12' },
-            ])('formats $value as $result using YEAR_MONTH_DAY_TIME format (now: $now)', ({ now, value, result }) => {
-                setTime(now);
-                expect(formatterUtils.formatDate(value, { format: DateFormat.YEAR_MONTH_DAY_TIME })).toEqual(result);
-            });
+            ])(
+                'formats $value as $result using YEAR_MONTH_DAY_TIME format (now: $now)',
+                ({ now, value, result, locale }) => {
+                    setLocale({ date: locale });
+                    setTime(now);
+                    expect(formatterUtils.formatDate(value, { format: DateFormat.YEAR_MONTH_DAY_TIME })).toEqual(
+                        result,
+                    );
+                },
+            );
         });
 
         describe('YEAR_MONTH_DAY format', () => {
             test.each([
                 { value: '2023-06-17T13:21:24', result: 'June 17, 2023' },
+                { value: '2023-06-17T13:21:24', result: '17 giugno 2023', locale: 'it' },
                 { value: '2018-01-01T10:11:12', result: 'January 1, 2018' },
                 { value: '2001-05-21T20:10:52', result: 'tomorrow', now: '2001-05-20T05:05:00' },
                 { value: '2001-05-20T23:55:59', result: 'today', now: '2001-05-20T05:05:00' },
@@ -265,18 +298,24 @@ describe('formatter utils', () => {
                 { value: '2001-05-19T22:05:01', result: 'yesterday', now: '2001-05-20T05:05:00' },
                 { value: '2001-05-18T23:05:01', result: 'May 18, 2001', now: '2001-05-20T05:05:00' },
                 { value: '2001-05-22T00:00:01', result: 'May 22, 2001', now: '2001-05-20T05:05:00' },
-            ])('formats $value as $result using YEAR_MONTH_DAY format (now: $now)', ({ now, value, result }) => {
-                setTime(now);
-                expect(formatterUtils.formatDate(value, { format: DateFormat.YEAR_MONTH_DAY })).toEqual(result);
-            });
+            ])(
+                'formats $value as $result using YEAR_MONTH_DAY format (now: $now)',
+                ({ now, value, result, locale }) => {
+                    setLocale({ date: locale });
+                    setTime(now);
+                    expect(formatterUtils.formatDate(value, { format: DateFormat.YEAR_MONTH_DAY })).toEqual(result);
+                },
+            );
         });
 
         describe('YEAR_MONTH format', () => {
             test.each([
                 { value: '2024-08-11T11:11:00', result: 'August 2024' },
+                { value: '2024-08-11T11:11:00', result: 'agosto 2024', locale: 'it' },
                 { value: '2012-10-01T10:01:10', result: 'October 2012' },
                 { value: '2027-01-01T09:05:10', result: 'January 2027', now: '2027-01-01T09:05:10' },
-            ])('formats $value as $result using YEAR_MONTH format (now: $now)', ({ value, result, now }) => {
+            ])('formats $value as $result using YEAR_MONTH format (now: $now)', ({ value, result, now, locale }) => {
+                setLocale({ date: locale });
                 setTime(now);
                 expect(formatterUtils.formatDate(value, { format: DateFormat.YEAR_MONTH })).toEqual(result);
             });
@@ -285,6 +324,7 @@ describe('formatter utils', () => {
         describe('DURATION format', () => {
             test.each([
                 { value: '2000-02-10T11:11:48', result: '7 seconds', now: '2000-02-10T11:11:55' },
+                { value: '2000-02-10T11:11:48', result: '7 secondi', now: '2000-02-10T11:11:55', locale: 'it' },
                 { value: '2000-02-10T11:11:48', result: '0 seconds', now: '2000-02-10T11:11:48' },
                 { value: '2000-02-10T11:11:45', result: '1 second', now: '2000-02-10T11:11:44' },
                 { value: '2000-02-10T11:12:59', result: '1 minute', now: '2000-02-10T11:11:10' },
@@ -297,7 +337,8 @@ describe('formatter utils', () => {
                 { value: '2002-03-03T22:12:08', result: '11 months', now: '2001-03-03T22:12:09' },
                 { value: '2002-03-03T22:12:09', result: '1 year', now: '2001-03-03T22:12:09' },
                 { value: '2024-06-25T22:12:09', result: '31 years', now: '1993-06-19T08:10:10' },
-            ])('formats $value as $result using DURATION format (now: $now)', ({ value, result, now }) => {
+            ])('formats $value as $result using DURATION format (now: $now)', ({ value, result, now, locale }) => {
+                setLocale({ date: locale });
                 setTime(now);
                 expect(formatterUtils.formatDate(value, { format: DateFormat.DURATION })).toEqual(result);
             });
@@ -306,6 +347,7 @@ describe('formatter utils', () => {
         describe('RELATIVE format', () => {
             test.each([
                 { value: '2020-02-09T20:17:41', result: '18 hours ago', now: '2020-02-10T14:39:51' },
+                { value: '2020-02-09T20:17:41', result: '18 ore fa', now: '2020-02-10T14:39:51', locale: 'it' },
                 { value: '2020-02-10T13:25:42', result: '1 hour ago', now: '2020-02-10T14:39:51' },
                 { value: '2020-02-10T13:58:44', result: '41 minutes ago', now: '2020-02-10T14:39:51' },
                 { value: '2020-02-10T14:39:49', result: '2 seconds ago', now: '2020-02-10T14:39:51' },
@@ -317,7 +359,8 @@ describe('formatter utils', () => {
                 { value: '2004-11-29T12:12:41', result: 'in 1 month', now: '2004-10-25T20:21:23' },
                 { value: '2011-10-10T11:01:00', result: 'in 1 year', now: '2010-04-10T11:01:00' },
                 { value: '2019-11-20T11:01:00', result: 'in 9 years', now: '2010-04-10T11:01:00' },
-            ])('formats $value as $result using RELATIVE format (now: $now)', ({ value, result, now }) => {
+            ])('formats $value as $result using RELATIVE format (now: $now)', ({ value, result, now, locale }) => {
+                setLocale({ date: locale });
                 setTime(now);
                 expect(formatterUtils.formatDate(value, { format: DateFormat.RELATIVE })).toEqual(result);
             });

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -166,7 +166,7 @@ describe('formatter utils', () => {
         describe('token prices', () => {
             test.each([
                 { value: -1234.56789, result: '-$1,234.57' },
-                { value: -1234.56789, result: '-1.234,57 USD', locale: 'it' },
+                { value: -1234.56789, result: '-1.234,57 USD', locale: 'it' },
                 { value: -0.0012345678, result: '-$0.001235' },
                 { value: 0, result: 'Unknown' },
                 { value: 0.0012345678, result: '$0.001235' },

--- a/src/core/utils/formatterUtils/formatterUtils.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.ts
@@ -150,7 +150,10 @@ class FormatterUtils {
         if (isDuration) {
             const dateDiff = dateObject.diffNow(this.relativeDateOrder);
             const nonZeroUnit = this.relativeDateOrder.find((unit) => Math.abs(dateDiff.get(unit)) > 0) ?? 'seconds';
-            const roundedDiffUnit = Duration.fromObject({ [nonZeroUnit]: Math.floor(dateDiff.get(nonZeroUnit)) });
+            const roundedDiffUnit = Duration.fromObject(
+                { [nonZeroUnit]: Math.floor(dateDiff.get(nonZeroUnit)) },
+                { locale: this.dateLocale },
+            );
 
             return roundedDiffUnit.valueOf() < 0 ? roundedDiffUnit.negate().toHuman() : roundedDiffUnit.toHuman();
         }

--- a/src/modules/components/odsModulesProvider/odsModulesProvider.mdx
+++ b/src/modules/components/odsModulesProvider/odsModulesProvider.mdx
@@ -5,12 +5,12 @@ import { OdsModulesProvider } from './odsModulesProvider';
 
 <Title>OdsModulesProvider</Title>
 
-The `<OdsModulesProvider />` is a simple wrapper around the `<WagmiProvider />` and `<QueryClientProvider />` React
-Context providers from the [wagmi](https://wagmi.sh/) and [@tanstack/react-query](https://tanstack.com/query) libraries.
+The `<OdsModulesProvider />` is a React context that, beside providing some customisations for the modules components,
+renders the `<WagmiProvider />` and `<QueryClientProvider />` React Context providers from the
+[wagmi](https://wagmi.sh/) and [@tanstack/react-query](https://tanstack.com/query) libraries.
 
 The two providers are needed for the ODS Modules component using the hooks from wagmi (e.g.
-[useEnsName](https://wagmi.sh/react/api/hooks/useEnsName)). In order to use these hooks, the application needs to be
-wrapped using the following providers:
+[useEnsName](https://wagmi.sh/react/api/hooks/useEnsName)):
 
 -   `<WagmiProvider />`: needed to know which chain and RPC endpoint to use when fetching blockchain data;
 -   `<QueryClientProvider />`: needed to cache the data fetched from the blockchain;
@@ -18,10 +18,9 @@ wrapped using the following providers:
 Additionally, `<OdsModulesProvider />` renders the `<OdsCoreProvider />` and passes values from the `coreProviderValues`
 prop.
 
-The `values` prop is used for module-specific configurations.
+The `<OdsModulesProvider />` provides the following customisations for modules components:
 
--   `values` (optional): Partial object of type `IOdsModulesContext` to override default context values.
-    -   `copy`: Object of type `IOdsModulesCopy` to customize the text labels used within the modules components.
+-   `copy`: Object of type `IOdsModulesCopy` to customize the text labels used within the modules components.
 
 Refer to the component's properties below for more details on the default configuration objects used for each provider.
 

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.test.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.test.tsx
@@ -46,7 +46,7 @@ describe('<ProposalDataListItemStatus /> component', () => {
 
         const formattedDate = formatterUtils.formatDate(date, { format: DateFormat.RELATIVE })!;
         expect(screen.getByText(status)).toBeInTheDocument();
-        expect(formattedDate).not.toBeInTheDocument();
+        expect(screen.queryByText(formattedDate)).not.toBeInTheDocument();
         expect(screen.queryByTestId(IconType.CALENDAR)).not.toBeInTheDocument();
     });
 

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.test.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.test.tsx
@@ -5,7 +5,10 @@ import { ProposalDataListItemStatus, type IProposalDataListItemStatusProps } fro
 
 describe('<ProposalDataListItemStatus /> component', () => {
     const createTestComponent = (props?: Partial<IProposalDataListItemStatusProps>) => {
-        const completeProps: IProposalDataListItemStatusProps = { date: 1719563030308, status: 'accepted', ...props };
+        const completeProps: IProposalDataListItemStatusProps = {
+            status: 'accepted',
+            ...props,
+        };
 
         return <ProposalDataListItemStatus {...completeProps} />;
     };
@@ -24,12 +27,15 @@ describe('<ProposalDataListItemStatus /> component', () => {
         expect(screen.getByTestId(IconType.CALENDAR)).toBeInTheDocument();
     });
 
-    it('does not render the calendar icon when date property is not defined', () => {
+    it('does not render the calendar icon and date when date property is not defined', () => {
         const status = 'accepted';
+        const date = undefined;
 
-        render(createTestComponent({ status, date: undefined }));
+        render(createTestComponent({ status, date }));
 
         expect(screen.queryByTestId(IconType.CALENDAR)).not.toBeInTheDocument();
+        expect(screen.queryByText(/ago/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/left/)).not.toBeInTheDocument();
     });
 
     it("only displays the date for proposals with a status that is not 'draft'", () => {
@@ -38,8 +44,9 @@ describe('<ProposalDataListItemStatus /> component', () => {
 
         render(createTestComponent({ date, status }));
 
+        const formattedDate = formatterUtils.formatDate(date, { format: DateFormat.RELATIVE })!;
         expect(screen.getByText(status)).toBeInTheDocument();
-        expect(screen.queryByText(date)).not.toBeInTheDocument();
+        expect(formattedDate).not.toBeInTheDocument();
         expect(screen.queryByTestId(IconType.CALENDAR)).not.toBeInTheDocument();
     });
 

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.tsx
@@ -10,6 +10,7 @@ import {
     type StatePingAnimationVariant,
     type TagVariant,
 } from '../../../../../core';
+import type { ModulesCopy } from '../../../../assets';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { type IProposalDataListItemStructureProps, type ProposalStatus } from '../proposalDataListItemStructure';
 
@@ -32,15 +33,22 @@ const statusToTagVariant: Record<ProposalStatus, TagVariant> = {
 };
 
 type OngoingProposalStatus = 'active' | 'challenged' | 'vetoed';
+
 const ongoingStatusToPingVariant: Record<OngoingProposalStatus, StatePingAnimationVariant> = {
     active: 'info',
     challenged: 'warning',
     vetoed: 'warning',
 };
 
-/**
- * `ProposalDataListItemStatus` local component
- */
+const getFormattedProposalDate = (date: string | number, now: number, copy: ModulesCopy) => {
+    const formattedDuration = formatterUtils.formatDate(date, { format: DateFormat.DURATION });
+
+    const suffix =
+        new Date(date).getTime() > now ? copy.proposalDataListItemStatus.left : copy.proposalDataListItemStatus.ago;
+
+    return `${formattedDuration} ${suffix}`;
+};
+
 export const ProposalDataListItemStatus: React.FC<IProposalDataListItemStatusProps> = (props) => {
     const { date, status, voted } = props;
 
@@ -62,23 +70,9 @@ export const ProposalDataListItemStatus: React.FC<IProposalDataListItemStatusPro
                             'text-neutral-800': ongoing === false,
                         })}
                     >
-                        {ongoingAndVoted ? (
-                            copy.proposalDataListItemStatus.voted
-                        ) : (
-                            <Rerender>
-                                {(now) => {
-                                    const formattedDuration = formatterUtils.formatDate(date, {
-                                        format: DateFormat.DURATION,
-                                    })!;
-
-                                    const suffix =
-                                        new Date(date!).getTime() > now
-                                            ? copy.proposalDataListItemStatus.left
-                                            : copy.proposalDataListItemStatus.ago;
-
-                                    return `${formattedDuration} ${suffix}`;
-                                }}
-                            </Rerender>
+                        {ongoingAndVoted && copy.proposalDataListItemStatus.voted}
+                        {!ongoingAndVoted && date != null && (
+                            <Rerender>{(now) => getFormattedProposalDate(date, now, copy)}</Rerender>
                         )}
                     </span>
                     {ongoingAndVoted && <AvatarIcon icon={IconType.CHECKMARK} responsiveSize={{ md: 'md' }} />}

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
@@ -2,6 +2,7 @@ import { type IDataListItemProps } from '../../../../../core';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../../types';
 
 export type ProposalType = 'majorityVoting' | 'approvalThreshold';
+
 export type ProposalStatus =
     | 'accepted'
     | 'active'
@@ -60,6 +61,7 @@ export interface IProposalDataListItemStructureBaseProps<TType extends ProposalT
      */
     voted?: boolean;
 }
+
 export interface IPublisher extends ICompositeAddress {
     /**
      * Link to additional information about the publisher, such as a profile page or block explorer.


### PR DESCRIPTION
## Description

- Fix `ProposalDataListItem` component to avoid showing `null ago` when date is not defined;
- Fix DURATION date format to use the locale defined on the formatter utils

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
