### PR TITLE
feat(APP-3460): Export VoteIndicator type, update buildEntityUrl function to support a chainId parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   Export `VoteIndicator` type from `Vote` module.
+-   Update `useBlockExplorer` hook to export a `getBlockExplorer` function, update `buildEntityUrl` function to support
+    a `chainId` parameter which overrides the `chainId` hook parameter.
+
 ## [1.0.40] - 2024-07-26
 
 ### Added

--- a/src/modules/components/vote/index.ts
+++ b/src/modules/components/vote/index.ts
@@ -1,2 +1,3 @@
 export * from './voteDataListItem';
 export * from './voteProposalDataListItem';
+export { VoteIndicator } from './voteUtils';

--- a/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
+++ b/src/modules/hooks/useBlockExplorer/useBlockExplorer.test.ts
@@ -39,7 +39,7 @@ describe('useBlockExplorer hook', () => {
             expect(result.current.getBlockExplorer()).toEqual(sepolia.blockExplorers?.default);
         });
 
-        it('returns the block explorer of the chain speficied on the hook when function chain-id parameter is not specified', () => {
+        it('returns the block explorer of the chain specified on the hook when function chain-id parameter is not specified', () => {
             const chains: [Chain, ...Chain[]] = [mainnet, polygon];
             const { result } = renderHook(() => useBlockExplorer({ chains, chainId: polygon.id }));
             expect(result.current.getBlockExplorer()).toEqual(polygon.blockExplorers.default);


### PR DESCRIPTION
## Description

- Export `VoteIndicator` type
- Update `useBlockExplorer` hook to export a `getBlockExplorer` function and update `buildEntityUrl` function to support a `chainId` parameter overriding the `chainId` parameter set on the hook.

Task: [APP-3460](https://aragonassociation.atlassian.net/browse/APP-3460)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3460]: https://aragonassociation.atlassian.net/browse/APP-3460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ