### PR TITLE
fix(APP-3461): Hide minParticipation details from token-voting breakdown when property is set to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Hide minimum participation details on `ProposalVotingBreakdownToken` module component when minParticipation is set
+    to zero.
+
 ## [1.0.41] - 2024-07-30
 
 ### Added

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
@@ -37,12 +37,6 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
         expect(() => render(createTestComponent({ tokenTotalSupply }))).toThrow();
     });
 
-    it('throws error when minParticipation is set to 0', () => {
-        testLogger.suppressErrors();
-        const minParticipation = 0;
-        expect(() => render(createTestComponent({ minParticipation }))).toThrow();
-    });
-
     it('renders a progress and proper description for each option based on the current votes and total votes', () => {
         const totalYes = 7000;
         const totalNo = 2000;
@@ -121,5 +115,11 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
 
         expect(progressbarContainer.getByText(formattedTotal)).toBeInTheDocument();
         expect(progressbarContainer.getByText(`of ${formattedMinParticipation} ${tokenSymbol}`)).toBeInTheDocument();
+    });
+
+    it('hides the minimum participation details when set to 0', () => {
+        const minParticipation = 0;
+        render(createTestComponent({ minParticipation }));
+        expect(screen.queryByText('Minimum participation')).not.toBeInTheDocument();
     });
 });

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
@@ -117,7 +117,7 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
         expect(progressbarContainer.getByText(`of ${formattedMinParticipation} ${tokenSymbol}`)).toBeInTheDocument();
     });
 
-    it('hides the minimum participation details when set to 0', () => {
+    it('hides the minimum participation details when minParticipation prop is set to 0', () => {
         const minParticipation = 0;
         render(createTestComponent({ minParticipation }));
         expect(screen.queryByText('Minimum participation')).not.toBeInTheDocument();

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
@@ -60,7 +60,6 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
     const totalSupplyNumber = Number(tokenTotalSupply);
 
     invariant(totalSupplyNumber > 0, 'ProposalVotingBreakdownToken: tokenTotalSupply must be a positive number');
-    invariant(minParticipation > 0, 'ProposalVotingBreakdownToken: minParticipation must be a positive number');
 
     const totalVotes = optionValues.reduce((accumulator, option) => accumulator + option.value, 0);
     const formattedTotalVotes = formatterUtils.formatNumber(totalVotes, { format: NumberFormat.GENERIC_SHORT });
@@ -114,19 +113,21 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
                     variant={supportReached ? 'primary' : 'neutral'}
                     thresholdIndicator={supportThreshold}
                 />
-                <ProposalVotingProgress.Item
-                    name={copy.proposalVotingBreakdownToken.minParticipation.name}
-                    value={currentParticipationPercentage}
-                    description={{
-                        value: formattedTotalVotes,
-                        text: copy.proposalVotingBreakdownToken.minParticipation.description(
-                            `${formattedMinParticipationToken} ${tokenSymbol}`,
-                        ),
-                    }}
-                    showPercentage={true}
-                    showStatusIcon={true}
-                    variant={minParticipationReached ? 'primary' : 'neutral'}
-                />
+                {minParticipation > 0 && (
+                    <ProposalVotingProgress.Item
+                        name={copy.proposalVotingBreakdownToken.minParticipation.name}
+                        value={currentParticipationPercentage}
+                        description={{
+                            value: formattedTotalVotes,
+                            text: copy.proposalVotingBreakdownToken.minParticipation.description(
+                                `${formattedMinParticipationToken} ${tokenSymbol}`,
+                            ),
+                        }}
+                        showPercentage={true}
+                        showStatusIcon={true}
+                        variant={minParticipationReached ? 'primary' : 'neutral'}
+                    />
+                )}
             </ProposalVotingProgress.Container>
             {children}
         </Tabs.Content>


### PR DESCRIPTION
## Description

- Hide minParticipation details from token-voting breakdown when property is set to zero

Task: [APP-3461](https://aragonassociation.atlassian.net/browse/APP-3461)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3461]: https://aragonassociation.atlassian.net/browse/APP-3461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ