### PR TITLE
fix(APP-3495): Correctly forward web3 parameters to native ProposalActions components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Hide minimum participation details on `ProposalVotingBreakdownToken` module component when minParticipation is set
     to zero.
+-   Correctly forward web3 params (e.g. `chainId`) to native `ProposalActions` components
 
 ## [1.0.41] - 2024-07-30
 

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
@@ -58,7 +58,7 @@ export const ProposalActions: React.FC<IProposalActionsProps> = (props) => {
                         action={action}
                         index={index}
                         name={actionNames?.[action.type]}
-                        customComponent={customActionComponents?.[action.type]}
+                        CustomComponent={customActionComponents?.[action.type]}
                         {...web3Props}
                     />
                 ))}

--- a/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.test.tsx
@@ -2,10 +2,24 @@ import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Accordion } from '../../../../../core';
 import { modulesCopy } from '../../../../assets';
+import {
+    generateProposalActionChangeMembers,
+    generateProposalActionChangeSettings,
+    generateProposalActionTokenMint,
+    generateProposalActionUpdateMetadata,
+} from '../actions/generators';
 import { generateProposalAction } from '../actions/generators/proposalAction';
 import { generateProposalActionWithdrawToken } from '../actions/generators/proposalActionWithdrawToken';
 import type { IProposalAction } from '../proposalActionsTypes';
 import { type IProposalActionsActionProps, ProposalActionsAction } from './proposalActionsAction';
+
+jest.mock('../actions', () => ({
+    ProposalActionWithdrawToken: () => <div data-testid="withdraw-token" />,
+    ProposalActionTokenMint: () => <div data-testid="token-mint" />,
+    ProposalActionUpdateMetadata: () => <div data-testid="update-metadata" />,
+    ProposalActionChangeMembers: () => <div data-testid="change-members" />,
+    ProposalActionChangeSettings: () => <div data-testid="change-settings" />,
+}));
 
 describe('<ProposalActionsAction /> component', () => {
     const createTestComponent = (props?: Partial<IProposalActionsActionProps>) => {
@@ -29,16 +43,16 @@ describe('<ProposalActionsAction /> component', () => {
     });
 
     it('renders custom action component when provided', async () => {
-        const customComponent = (props: { action: IProposalAction }) => `Custom action for ${props.action.type}`;
+        const CustomComponent = (props: { action: IProposalAction }) => props.action.type;
         const action = generateProposalAction({
             type: 'customType',
             inputData: { function: 'transfer', contract: 'DAI', parameters: [] },
         });
 
-        render(createTestComponent({ action, customComponent }));
+        render(createTestComponent({ action, CustomComponent }));
 
         await userEvent.click(screen.getByText('transfer'));
-        expect(screen.getByText(`Custom action for ${action.type}`)).toBeInTheDocument();
+        expect(screen.getByText(action.type)).toBeInTheDocument();
     });
 
     it('renders action name when provided and contract is verified', () => {
@@ -46,5 +60,17 @@ describe('<ProposalActionsAction /> component', () => {
         const name = 'Custom Action Name';
         render(createTestComponent({ name, action }));
         expect(screen.getByText(name)).toBeInTheDocument();
+    });
+
+    it.each([
+        { action: generateProposalActionWithdrawToken(), testId: 'withdraw-token' },
+        { action: generateProposalActionTokenMint(), testId: 'token-mint' },
+        { action: generateProposalActionUpdateMetadata(), testId: 'update-metadata' },
+        { action: generateProposalActionChangeMembers(), testId: 'change-members' },
+        { action: generateProposalActionChangeSettings(), testId: 'change-settings' },
+    ])('renders correct UI for $testId action', async ({ action, testId }) => {
+        render(createTestComponent({ action }));
+        await userEvent.click(screen.getByRole('button'));
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
@@ -1,7 +1,15 @@
+import { useMemo } from 'react';
 import { Accordion, Heading } from '../../../../../core';
 import type { IWeb3ComponentProps } from '../../../../types';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
-import { ProposalActionsActionVerification } from '../proposalActionsActionVerfication/proposalActionsActionVerfication';
+import {
+    ProposalActionChangeMembers,
+    ProposalActionChangeSettings,
+    ProposalActionTokenMint,
+    ProposalActionUpdateMetadata,
+    ProposalActionWithdrawToken,
+} from '../actions';
+import { ProposalActionsActionVerification } from '../proposalActionsActionVerfication';
 import type { IProposalAction, ProposalActionComponent } from '../proposalActionsTypes';
 import { proposalActionsUtils } from '../proposalActionsUtils';
 
@@ -21,15 +29,36 @@ export interface IProposalActionsActionProps extends IWeb3ComponentProps {
     /**
      * Custom component for the action
      */
-    customComponent?: ProposalActionComponent;
+    CustomComponent?: ProposalActionComponent;
 }
 
 export const ProposalActionsAction: React.FC<IProposalActionsActionProps> = (props) => {
-    const { action, index, name, customComponent, ...web3Props } = props;
-
-    const ActionComponent = customComponent ?? proposalActionsUtils.getActionComponent(action);
+    const { action, index, name, CustomComponent, ...web3Props } = props;
 
     const { copy } = useOdsModulesContext();
+
+    const ActionComponent = useMemo(() => {
+        if (CustomComponent) {
+            return <CustomComponent action={action} {...web3Props} />;
+        }
+
+        if (proposalActionsUtils.isWithdrawTokenAction(action)) {
+            return <ProposalActionWithdrawToken action={action} {...web3Props} />;
+        } else if (proposalActionsUtils.isTokenMintAction(action)) {
+            return <ProposalActionTokenMint action={action} {...web3Props} />;
+        } else if (proposalActionsUtils.isUpdateMetadataAction(action)) {
+            return <ProposalActionUpdateMetadata action={action} {...web3Props} />;
+        } else if (proposalActionsUtils.isChangeMembersAction(action)) {
+            return <ProposalActionChangeMembers action={action} {...web3Props} />;
+        } else if (proposalActionsUtils.isChangeSettingsAction(action)) {
+            return <ProposalActionChangeSettings action={action} {...web3Props} />;
+        }
+
+        return null;
+    }, [action, CustomComponent, web3Props]);
+
+    const defaultTitle = name ?? action.inputData?.function;
+    const actionTitle = action.inputData == null ? copy.proposalActionsAction.notVerified : defaultTitle;
 
     const isDisabled = action.inputData == null;
 
@@ -37,17 +66,11 @@ export const ProposalActionsAction: React.FC<IProposalActionsActionProps> = (pro
         <Accordion.Item value={isDisabled ? '' : `${index}`} disabled={isDisabled}>
             <Accordion.ItemHeader>
                 <div className="flex flex-col items-start">
-                    <Heading size="h4">
-                        {action.inputData == null
-                            ? copy.proposalActionsAction.notVerified
-                            : (name ?? action.inputData.function)}
-                    </Heading>
+                    <Heading size="h4">{actionTitle}</Heading>
                     <ProposalActionsActionVerification action={action} />
                 </div>
             </Accordion.ItemHeader>
-            <Accordion.ItemContent>
-                {ActionComponent && <ActionComponent action={action} {...web3Props} />}
-            </Accordion.ItemContent>
+            <Accordion.ItemContent>{ActionComponent}</Accordion.ItemContent>
         </Accordion.Item>
     );
 };

--- a/src/modules/components/proposal/proposalActions/proposalActionsUtils.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsUtils.test.tsx
@@ -1,6 +1,4 @@
-import { render, screen } from '@testing-library/react';
 import {
-    generateProposalAction,
     generateProposalActionChangeMembers,
     generateProposalActionChangeSettings,
     generateProposalActionTokenMint,
@@ -10,75 +8,74 @@ import {
 import { ProposalActionType } from './proposalActionsTypes';
 import { proposalActionsUtils } from './proposalActionsUtils';
 
-jest.mock('./actions', () => ({
-    ProposalActionWithdrawToken: () => <div>Mock ProposalActionWithdrawToken</div>,
-    ProposalActionUpdateMetadata: () => <div>Mock ProposalActionUpdateMetaData</div>,
-    ProposalActionTokenMint: () => <div>Mock ProposalActionTokenMint</div>,
-    ProposalActionChangeMembers: () => <div>Mock ProposalActionChangeMembers</div>,
-    ProposalActionChangeSettings: () => <div>Mock ProposalActionChangeSettings</div>,
-}));
-
 describe('ProposalActions utils', () => {
-    it('returns ProposalActionWithdrawToken component for withdrawToken action', () => {
-        const action = generateProposalActionWithdrawToken();
+    describe('isWithdrawTokenAction', () => {
+        it('returns true for withdraw action', () => {
+            const action = generateProposalActionWithdrawToken();
+            expect(proposalActionsUtils.isWithdrawTokenAction(action)).toBeTruthy();
+        });
 
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionWithdrawToken')).toBeInTheDocument();
+        it('returns false for other actions', () => {
+            const action = generateProposalActionUpdateMetadata();
+            expect(proposalActionsUtils.isWithdrawTokenAction(action)).toBeFalsy();
+        });
     });
 
-    it('returns ProposalActionUpdateMetadata component for updateMetadata action', () => {
-        const action = generateProposalActionUpdateMetadata();
+    describe('isChangeMemberAction', () => {
+        it('returns true for change members actions', () => {
+            const addMembersAction = generateProposalActionChangeMembers({ type: ProposalActionType.ADD_MEMBERS });
+            const removeMembersAction = generateProposalActionChangeMembers({
+                type: ProposalActionType.REMOVE_MEMBERS,
+            });
+            expect(proposalActionsUtils.isChangeMembersAction(addMembersAction)).toBeTruthy();
+            expect(proposalActionsUtils.isChangeMembersAction(removeMembersAction)).toBeTruthy();
+        });
 
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionUpdateMetaData')).toBeInTheDocument();
+        it('returns false for other actions', () => {
+            const action = generateProposalActionWithdrawToken();
+            expect(proposalActionsUtils.isChangeMembersAction(action)).toBeFalsy();
+        });
     });
 
-    it('returns ProposalActionTokenMint component for tokenMint action', () => {
-        const action = generateProposalActionTokenMint();
+    describe('isUpdateMetadataAction', () => {
+        it('returns true for update metadata action', () => {
+            const action = generateProposalActionUpdateMetadata();
+            expect(proposalActionsUtils.isUpdateMetadataAction(action)).toBeTruthy();
+        });
 
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionTokenMint')).toBeInTheDocument();
+        it('returns false for other actions', () => {
+            const action = generateProposalActionChangeMembers();
+            expect(proposalActionsUtils.isUpdateMetadataAction(action)).toBeFalsy();
+        });
     });
 
-    it('returns ProposalActionChangeMembers component for addMember action', () => {
-        const action = generateProposalActionChangeMembers({ type: ProposalActionType.ADD_MEMBERS });
+    describe('isTokenMintAction', () => {
+        it('returns true for token mint action', () => {
+            const action = generateProposalActionTokenMint();
+            expect(proposalActionsUtils.isTokenMintAction(action)).toBeTruthy();
+        });
 
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionChangeMembers')).toBeInTheDocument();
+        it('returns false for other actions', () => {
+            const action = generateProposalActionUpdateMetadata();
+            expect(proposalActionsUtils.isTokenMintAction(action)).toBeFalsy();
+        });
     });
 
-    it('returns ProposalActionChangeMembers component for removeMember action', () => {
-        const action = generateProposalActionChangeMembers({ type: ProposalActionType.REMOVE_MEMBERS });
+    describe('isChangeSettingsAction', () => {
+        it('returns true for change settings actions', () => {
+            const changeMultisig = generateProposalActionChangeSettings({
+                type: ProposalActionType.CHANGE_SETTINGS_MULTISIG,
+            });
+            const changeToken = generateProposalActionChangeSettings({
+                type: ProposalActionType.CHANGE_SETTINGS_TOKENVOTE,
+            });
+            expect(proposalActionsUtils.isChangeSettingsAction(changeMultisig)).toBeTruthy();
+            expect(proposalActionsUtils.isChangeSettingsAction(changeToken)).toBeTruthy();
+        });
 
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionChangeMembers')).toBeInTheDocument();
-    });
-
-    it('returns ProposalActionChangeSettings component for Multisig action', () => {
-        const action = generateProposalActionChangeSettings({ type: ProposalActionType.CHANGE_SETTINGS_MULTISIG });
-
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionChangeSettings')).toBeInTheDocument();
-    });
-
-    it('returns ProposalActionChangeSettings component for TokenVote action', () => {
-        const action = generateProposalActionChangeSettings({ type: ProposalActionType.CHANGE_SETTINGS_TOKENVOTE });
-
-        const Component = proposalActionsUtils.getActionComponent(action)!;
-        render(<Component />);
-        expect(screen.getByText('Mock ProposalActionChangeSettings')).toBeInTheDocument();
-    });
-
-    it('returns null for unknown action type', () => {
-        const action = generateProposalAction();
-
-        const Component = proposalActionsUtils.getActionComponent(action);
-        expect(Component).toBeNull();
+        it('returns false for other actions', () => {
+            const action = generateProposalActionTokenMint();
+            expect(proposalActionsUtils.isChangeSettingsAction(action)).toBeFalsy();
+        });
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsUtils.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsUtils.ts
@@ -1,11 +1,4 @@
 import {
-    ProposalActionChangeMembers,
-    ProposalActionChangeSettings,
-    ProposalActionTokenMint,
-    ProposalActionUpdateMetadata,
-    ProposalActionWithdrawToken,
-} from './actions';
-import {
     type IProposalAction,
     type IProposalActionChangeMembers,
     type IProposalActionChangeSettings,
@@ -16,22 +9,6 @@ import {
 } from './proposalActionsTypes';
 
 class ProposalActionsUtils {
-    getActionComponent = (action: IProposalAction) => {
-        if (this.isWithdrawTokenAction(action)) {
-            return () => ProposalActionWithdrawToken({ action });
-        } else if (this.isTokenMintAction(action)) {
-            return () => ProposalActionTokenMint({ action });
-        } else if (this.isUpdateMetadataAction(action)) {
-            return () => ProposalActionUpdateMetadata({ action });
-        } else if (this.isChangeMembersAction(action)) {
-            return () => ProposalActionChangeMembers({ action });
-        } else if (this.isChangeSettingsAction(action)) {
-            return () => ProposalActionChangeSettings({ action });
-        }
-
-        return null;
-    };
-
     isWithdrawTokenAction = (action: Partial<IProposalAction>): action is IProposalActionWithdrawToken => {
         return action.type === ProposalActionType.WITHDRAW_TOKEN;
     };


### PR DESCRIPTION
## Description

- Correctly forward web3 parameters to native ProposalActions components

Task: [APP-3495](https://aragonassociation.atlassian.net/browse/APP-3495)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3495]: https://aragonassociation.atlassian.net/browse/APP-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ