### PR TITLE
fix: Use correct percentage format on AssetDataListItemStructure module component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Use correct percentage formatting on `<AssetDataListItem />` module component
+
 ## [1.0.44] - 2024-08-20
 
 ### Added

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.test.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.test.tsx
@@ -20,53 +20,31 @@ describe('<AssetDataListItem.Structure /> component', () => {
         );
     };
 
-    it('renders tokenName and symbol', () => {
-        const props = {
-            name: 'Ethereum',
-            symbol: 'ETH',
-            amount: 420.69,
-        };
-
+    it('renders token name and symbol', () => {
+        const props = { name: 'Ethereum', symbol: 'ETH' };
         render(createTestComponent(props));
         expect(screen.getByText(props.name)).toBeInTheDocument();
         expect(screen.getByText(props.symbol)).toBeInTheDocument();
     });
 
-    it('renders amount, fiat price', async () => {
-        const props = {
-            name: 'Ethereum',
-            symbol: 'ETH',
-            amount: 420.69,
-            fiatPrice: 3654.76,
-        };
-
+    it('correctly renders amount, fiat price and price change', () => {
+        const props = { amount: 10, fiatPrice: 1250, priceChange: 25 };
         render(createTestComponent(props));
-        const USDAmount = await screen.findByText(/1.54/);
-        expect(USDAmount).toHaveTextContent('$1.54M');
+        expect(screen.getByText('$12.50K')).toBeInTheDocument();
         expect(screen.getByText(props.amount)).toBeInTheDocument();
+        expect(screen.getByText('+$2.50K')).toBeInTheDocument();
+        expect(screen.getByText('+25.00%')).toBeInTheDocument();
     });
 
-    it('handles not passing fiat price', () => {
-        const props = {
-            name: 'Ethereum',
-            symbol: 'ETH',
-            amount: 0,
-            priceChange: 0,
-        };
-
+    it('renders unknown with fiatPrice is not set', () => {
+        const props = { fiatPrice: undefined };
         render(createTestComponent(props));
-        expect(screen.getByText('Unknown')).toBeInTheDocument(); // Assuming Tag component renders '0%' for zero priceChange
+        expect(screen.getByText('Unknown')).toBeInTheDocument();
     });
 
-    it('handle not passing priceChange', async () => {
-        const props = {
-            name: 'Ethereum',
-            amount: 420.69,
-            symbol: 'ETH',
-            fiatPrice: 3654.76,
-        };
-
+    it('correctly renders price change when fiatPrice is set but priceChange property is undefined', () => {
+        const props = { priceChange: undefined, fiatPrice: 10 };
         render(createTestComponent(props));
-        expect(screen.getByText('0%')).toBeInTheDocument();
+        expect(screen.getByText('0.00%')).toBeInTheDocument();
     });
 });

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -37,7 +37,7 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
 
     const { copy } = useOdsModulesContext();
 
-    const fiatAmount = Number(amount ?? 0) * Number(fiatPrice ?? 0);
+    const fiatAmount = Number(amount) * Number(fiatPrice ?? 0);
 
     const fiatAmountChanged = useMemo(() => {
         if (!fiatPrice || !priceChange) {
@@ -45,6 +45,7 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
         }
 
         const oldFiatAmount = (100 / (priceChange + 100)) * fiatAmount;
+
         return fiatAmount - oldFiatAmount;
     }, [fiatAmount, fiatPrice, priceChange]);
 

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -26,7 +26,7 @@ export interface IAssetDataListItemStructureProps extends IDataListItemProps {
      */
     fiatPrice?: number | string;
     /**
-     * The price change in percentage of the asset (E.g. in last 24h).
+     * The price change in percentage of the asset.
      * @default 0
      */
     priceChange?: number;
@@ -34,6 +34,8 @@ export interface IAssetDataListItemStructureProps extends IDataListItemProps {
 
 export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructureProps> = (props) => {
     const { logoSrc, name, amount, symbol, fiatPrice, priceChange = 0, ...otherProps } = props;
+
+    const { copy } = useOdsModulesContext();
 
     const fiatAmount = Number(amount ?? 0) * Number(fiatPrice ?? 0);
 
@@ -45,8 +47,6 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
         const oldFiatAmount = (100 / (priceChange + 100)) * fiatAmount;
         return fiatAmount - oldFiatAmount;
     }, [fiatAmount, fiatPrice, priceChange]);
-
-    const { copy } = useOdsModulesContext();
 
     const changedAmountClasses = classNames(
         'text-sm font-normal leading-tight md:text-base',

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -73,7 +73,7 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
     });
 
     const formattedPriceChangedPercentage = formatterUtils.formatNumber(priceChange / 100, {
-        format: NumberFormat.PERCENTAGE_SHORT,
+        format: NumberFormat.PERCENTAGE_LONG,
         withSign: true,
     });
 


### PR DESCRIPTION
## Description

Using the wrong format for percentages. Wasn't noticed until we fixed issue APP-3417.

Task: Related to APP-3417

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
