### PR TITLE
fix(APP-3308): Fix TextAreaRichText component to expose empty string as default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Bump `actions/setup-python` from 5.1.1 to 5.2.0
 -   Bump `express` from 4.19.2 to 4.21.0
 
+### Fixed
+
+-   Fix the `TextAreaRichText` core component to expose empty string as default value instead of empty paragraph
+
 ## [1.0.45] - 2024-08-23
 
 ### Added

--- a/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import ReactDOM from 'react-dom';
 import { IconType } from '../../icon';
@@ -50,8 +50,18 @@ describe('<TextAreaRichText /> component', () => {
     it('calls the onChange property on input change', async () => {
         const onChange = jest.fn();
         render(createTestComponent({ onChange }));
-        fireEvent.input(await screen.findByRole('textbox'), 'test');
-        expect(onChange).toHaveBeenCalled();
+        await userEvent.type(await screen.findByRole('textbox'), 'test');
+        // userEvent.type adds a new line character (\n\n) before tests causing the onChange callback
+        // to be called with an empty paragraph before the typed text
+        expect(onChange).toHaveBeenLastCalledWith('<p></p><p>test</p>');
+    });
+
+    it('defaults to empty string instead of empty paragraph when input is empty', async () => {
+        const onChange = jest.fn();
+        render(createTestComponent({ onChange }));
+        await userEvent.type(await screen.findByRole('textbox'), 'test');
+        await userEvent.clear(screen.getByRole('textbox'));
+        expect(onChange).toHaveBeenLastCalledWith('');
     });
 
     it('renders the textarea as a React portal on expand action click', async () => {

--- a/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
@@ -66,7 +66,10 @@ export const TextAreaRichText: React.FC<ITextAreaRichTextProps> = (props) => {
                 'aria-labelledby': randomId,
             },
         },
-        onUpdate: ({ editor }) => onChange?.(editor.getHTML()),
+        onUpdate: ({ editor }) => {
+            const value = editor.getText() !== '' ? editor.getHTML() : '';
+            onChange?.(value);
+        },
     });
 
     const toggleExpanded = () => setIsExpanded((current) => !current);

--- a/src/core/test/setup.ts
+++ b/src/core/test/setup.ts
@@ -4,7 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { TextDecoder, TextEncoder } from 'util';
-import { testLogger } from './utils';
+import { createRangeMock, testLogger } from './utils';
 
 // Setup test logger
 testLogger.setup();
@@ -15,4 +15,9 @@ Object.assign(global, { TextDecoder, TextEncoder });
 if (typeof window !== 'undefined') {
     // Mock scrollIntoView function
     HTMLElement.prototype.scrollIntoView = jest.fn();
+
+    // Mock elementFromPoint function
+    document.elementFromPoint = jest.fn();
+
+    createRangeMock();
 }

--- a/src/core/test/utils/createRangeMock.ts
+++ b/src/core/test/utils/createRangeMock.ts
@@ -1,0 +1,37 @@
+export const createRangeMock = () => {
+    document.createRange = () => {
+        const range = new Range();
+
+        range.getBoundingClientRect = () => ({
+            width: 0,
+            height: 0,
+            x: 0,
+            y: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+            toJSON: jest.fn(),
+        });
+
+        range.getClientRects = () => {
+            return {
+                item: () => ({
+                    width: 0,
+                    height: 0,
+                    x: 0,
+                    y: 0,
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    top: 0,
+                    toJSON: jest.fn(),
+                }),
+                length: 0,
+                [Symbol.iterator]: jest.fn(),
+            };
+        };
+
+        return range;
+    };
+};

--- a/src/core/test/utils/index.ts
+++ b/src/core/test/utils/index.ts
@@ -1,1 +1,2 @@
+export { createRangeMock } from './createRangeMock';
 export { testLogger } from './testLogger';


### PR DESCRIPTION
## Description

- Expose empty string instead of empty paragraph (`<p></p>`) as default value on TextAreaRichText component

Task: [APP-3308](https://aragonassociation.atlassian.net/browse/APP-3308)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3308]: https://aragonassociation.atlassian.net/browse/APP-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ