### PR TITLE
feat(APP-3614): Support dropdown-item actions on ProposalActions, update DataListItem to support standalone usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   Fix the `TextAreaRichText` core component to expose empty string as default value instead of empty paragraph
+-   Update `DropdownItem` style to correctly render items with icons aligned on the left
 
 ## [1.0.45] - 2024-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Add `IconType.BLOCKCHAIN_WALLETCONNECT` and associated asset
 -   Add `EmptyState` fallback to ProposalActions when no actions provided
+-   Support `dropdownItems` property on `ProposalActions` module component to display custom actions
 
 ### Changed
 
--   Update minor and patch versions of NPM dependencies
--   Bump `micromatch` from 4.0.7 to 4.0.8
--   Bump `webpack` from 5.91.0 to 5.94.0
 -   Update layout of `EmptyState` for centering
 -   Update `AccordionItem` border classes for usage within bordered containers
 -   Update `ProposalAction` to handle an `EmptyState` fallback for no actions passed, improve layout of children with
     "Expand all" (eg. 'Execute actions' button, etc)
+-   Update `DataListItem` component to support button rendering and standalone usage
+-   Update minor and patch versions of NPM dependencies
+-   Bump `micromatch` from 4.0.7 to 4.0.8
+-   Bump `webpack` from 5.91.0 to 5.94.0
 -   Bump `actions/setup-python` from 5.1.1 to 5.2.0
 -   Bump `express` from 4.19.2 to 4.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Update `ProposalAction` to handle an `EmptyState` fallback for no actions passed, improve layout of children with
     "Expand all" (eg. 'Execute actions' button, etc)
 -   Update `DataListItem` component to support button rendering and standalone usage
+-   Make `IProposalAction` type generic on ProposalAction module component to support actions with additional parameters
+    when used inside a form (e.g. actions with an additional `index` parameter)
 -   Update minor and patch versions of NPM dependencies
 -   Bump `micromatch` from 4.0.7 to 4.0.8
 -   Bump `webpack` from 5.91.0 to 5.94.0

--- a/src/core/components/dataList/dataListContext/dataListContext.ts
+++ b/src/core/components/dataList/dataListContext/dataListContext.ts
@@ -22,7 +22,7 @@ export interface IDataListContext
     handleLoadMore: (newPage: number) => void;
 }
 
-const dataListContext = createContext<IDataListContext | null>(null);
+export const dataListContext = createContext<IDataListContext | null>(null);
 
 export const DataListContextProvider = dataListContext.Provider;
 

--- a/src/core/components/dataList/dataListContext/index.ts
+++ b/src/core/components/dataList/dataListContext/index.ts
@@ -1,1 +1,1 @@
-export { DataListContextProvider, useDataListContext, type IDataListContext } from './dataListContext';
+export { DataListContextProvider, dataListContext, useDataListContext, type IDataListContext } from './dataListContext';

--- a/src/core/components/dataList/dataListItem/dataListItem.stories.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.stories.tsx
@@ -18,14 +18,30 @@ type Story = StoryObj<typeof DataList.Item>;
  * Default usage example of the DataList.Item component.
  */
 export const Default: Story = {
-    args: {},
-    render: (props) => (
-        <DataList.Root entityLabel="Users">
-            <DataList.Container>
-                <DataList.Item {...props}>Data List Item</DataList.Item>
-            </DataList.Container>
-        </DataList.Root>
-    ),
+    args: {
+        children: 'Data list item',
+    },
+};
+
+/**
+ * Usage of the DataList.Item component as link.
+ */
+export const Link: Story = {
+    args: {
+        children: 'Link data list item',
+        href: 'https://aragon.org',
+        target: '_blank',
+    },
+};
+
+/**
+ * Usage of the DataList.Item component as button.
+ */
+export const Button: Story = {
+    args: {
+        children: 'Button data list item',
+        onClick: () => null,
+    },
 };
 
 export default meta;

--- a/src/core/components/dataList/dataListItem/dataListItem.test.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.test.tsx
@@ -6,11 +6,15 @@ import { DataListItem, type IDataListItemProps } from './dataListItem';
 describe('<DataList.Item /> component', () => {
     const createTestComponent = (values?: {
         props?: Partial<IDataListItemProps>;
-        context?: Partial<IDataListContext>;
+        context?: Partial<IDataListContext> | null;
     }) => {
         const completeProps = {
             ...values?.props,
         };
+
+        if (values?.context === null) {
+            return <DataListItem {...completeProps} />;
+        }
 
         return (
             <DataListContextProvider value={dataListTestUtils.generateContextValues(values?.context)}>
@@ -19,10 +23,12 @@ describe('<DataList.Item /> component', () => {
         );
     };
 
-    it('renders a link with the given content', () => {
+    it('renders an interactive link with the given content when href property is set', () => {
         const props = { children: 'test-data-list-item', href: '/test' };
         render(createTestComponent({ props }));
-        expect(screen.getByRole('link', { name: props.children })).toBeInTheDocument();
+        const link = screen.getByRole('link', { name: props.children });
+        expect(link).toBeInTheDocument();
+        expect(link.classList).toContain('cursor-pointer');
     });
 
     it('marks the item as hidden when the data list is on initialLoading state', () => {
@@ -37,5 +43,24 @@ describe('<DataList.Item /> component', () => {
         const props = { href: '/test' };
         render(createTestComponent({ context, props }));
         expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('does not throw error when not placed inside the DataListContextProvider', () => {
+        const context = null;
+        expect(() => render(createTestComponent({ context }))).not.toThrow();
+    });
+
+    it('renders the item as an interactive button when onClick property is set', () => {
+        const props = { onClick: jest.fn() };
+        render(createTestComponent({ props }));
+        const button = screen.getByRole('button');
+        expect(button).toBeInTheDocument();
+        expect(button.classList).toContain('cursor-pointer');
+    });
+
+    it('renders the item as a non interactive button when both onClick and href property are not set', () => {
+        const props = { onClick: undefined, href: undefined };
+        render(createTestComponent({ props }));
+        expect(screen.getByRole('button').classList).not.toContain('cursor-pointer');
     });
 });

--- a/src/core/components/dataList/dataListItem/dataListItem.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.tsx
@@ -19,11 +19,11 @@ export const DataListItem: React.FC<IDataListItemProps> = (props) => {
     const isInteractiveElement = !isSkeletonElement && (isLinkElement || props.onClick != null);
 
     const actionItemClasses = classNames(
-        'w-full rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 outline-none transition-all focus:outline-none', // Default
+        'w-full rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 text-left outline-none transition-all focus:outline-none', // Default
         { 'focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset': isInteractiveElement }, // Interactive focus state
         { 'hover:border-neutral-200 hover:shadow-neutral-md active:border-neutral-300': isInteractiveElement }, // Interactive hover state
         { 'cursor-pointer': isInteractiveElement }, // Interactive default state
-        { 'cursor-default text-left ': !isInteractiveElement }, // Non-interactive default state
+        { 'cursor-default': !isInteractiveElement }, // Non-interactive default state
         'md:px-6 md:py-3.5', // Responsive
         className,
     );

--- a/src/core/components/dataList/dataListItem/dataListItem.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.tsx
@@ -1,37 +1,44 @@
 import classNames from 'classnames';
-import type { ComponentPropsWithoutRef } from 'react';
+import { type AnchorHTMLAttributes, type ButtonHTMLAttributes, useContext } from 'react';
 import { LinkBase } from '../../link';
-import { useDataListContext } from '../dataListContext';
+import { dataListContext } from '../dataListContext';
 
-export interface IDataListItemProps extends ComponentPropsWithoutRef<'a'> {}
+export type IDataListItemProps = ButtonHTMLAttributes<HTMLButtonElement> | AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const DataListItem: React.FC<IDataListItemProps> = (props) => {
-    const { children, className, href, ...otherProps } = props;
+    const { className, ...otherProps } = props;
 
-    const { state, childrenItemCount } = useDataListContext();
+    // Use the dataListContext directly to support usage of DataListItem component outside the DataListContextProvider.
+    const { state, childrenItemCount } = useContext(dataListContext) ?? {};
 
     // The DataListElement is a skeleton element on initial loading or loading state when no items are being
     // rendered (e.g. after a reset filters action)
     const isSkeletonElement = state === 'initialLoading' || (state === 'loading' && childrenItemCount === 0);
 
+    const isLinkElement = 'href' in otherProps && otherProps.href != null && otherProps.href !== '';
+    const isInteractiveElement = !isSkeletonElement && (isLinkElement || props.onClick != null);
+
     const actionItemClasses = classNames(
-        'rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 transition-all', // Default
-        'focus:outline-none focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset', // Focus state
-        { 'hover:border-neutral-200 hover:shadow-neutral-md active:border-neutral-300': !isSkeletonElement }, // Hover states when not skeleton
-        { 'cursor-pointer': !isSkeletonElement }, // Not skeleton element
+        'w-full rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 outline-none transition-all focus:outline-none', // Default
+        { 'focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset': isInteractiveElement }, // Interactive focus state
+        { 'hover:border-neutral-200 hover:shadow-neutral-md active:border-neutral-300': isInteractiveElement }, // Interactive hover state
+        { 'cursor-pointer': isInteractiveElement }, // Interactive default state
+        { 'cursor-default text-left ': !isInteractiveElement }, // Non-interactive default state
         'md:px-6 md:py-3.5', // Responsive
         className,
     );
 
-    return (
-        <LinkBase
-            className={actionItemClasses}
-            href={href}
-            aria-hidden={isSkeletonElement}
-            tabIndex={isSkeletonElement ? -1 : 0}
-            {...otherProps}
-        >
-            {children}
-        </LinkBase>
-    );
+    const commonProps = {
+        className: actionItemClasses,
+        'aria-hidden': isSkeletonElement,
+        tabIndex: isSkeletonElement ? -1 : 0,
+    };
+
+    if (!isLinkElement) {
+        const { type = 'button', ...buttonProps } = otherProps as ButtonHTMLAttributes<HTMLButtonElement>;
+
+        return <button type={type} {...commonProps} {...buttonProps} />;
+    }
+
+    return <LinkBase {...commonProps} {...otherProps} />;
 };

--- a/src/core/components/dataList/dataListRoot/dataListRoot.test.tsx
+++ b/src/core/components/dataList/dataListRoot/dataListRoot.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { Button } from '../../button';
 import { useDataListContext } from '../dataListContext';
 import { DataListItem } from '../dataListItem';
 import { DataListRoot, type IDataListRootProps } from './dataListRoot';
@@ -29,11 +28,7 @@ describe('<DataList.Root /> component', () => {
         const ChildrenComponent = () => {
             const { currentPage, handleLoadMore } = useDataListContext();
 
-            return (
-                <DataListItem>
-                    <Button onClick={() => handleLoadMore(currentPage + 1)}>{currentPage}</Button>
-                </DataListItem>
-            );
+            return <button onClick={() => handleLoadMore(currentPage + 1)}>{currentPage}</button>;
         };
 
         render(

--- a/src/core/components/dropdown/dropdownItem/dropdownItem.tsx
+++ b/src/core/components/dropdown/dropdownItem/dropdownItem.tsx
@@ -68,15 +68,15 @@ export const DropdownItem: React.FC<IDropdownItemProps> = (props) => {
             disabled={disabled}
             asChild={renderLink}
             className={classNames(
-                'flex items-center justify-between gap-3 px-4 py-3', // Layout
+                'flex items-center gap-3 px-4 py-3', // Layout
                 'cursor-pointer rounded-xl text-base leading-tight focus-visible:outline-none', // Style
                 'data-[disabled]:cursor-default data-[disabled]:bg-neutral-0 data-[disabled]:text-neutral-300', // Disabled
                 { 'bg-neutral-0 text-neutral-500': !selected && !disabled }, // Not selected
                 { 'bg-neutral-50 text-neutral-800': selected && !disabled }, // Selected
                 { 'hover:bg-neutral-50 hover:text-neutral-800': !disabled }, // Hover
                 { 'data-[highlighted]:bg-neutral-50 data-[highlighted]:text-neutral-800': !disabled }, // Highlighted
-                { 'flex-row': iconPosition === 'right' },
-                { 'flex-row-reverse': iconPosition === 'left' && icon != null },
+                { 'flex-row justify-between': iconPosition === 'right' },
+                { 'flex-row-reverse justify-end': iconPosition === 'left' && icon != null },
                 className,
             )}
             {...otherProps}

--- a/src/modules/assets/copy/modulesCopy.ts
+++ b/src/modules/assets/copy/modulesCopy.ts
@@ -33,6 +33,7 @@ export const modulesCopy = {
         },
     },
     proposalActionsAction: {
+        dropdownLabel: 'More',
         notVerified: 'Not verified',
         nativeSendAlert: 'Proceed with caution',
         nativeSendDescription: (amount: string) =>

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { AssetDataListItem } from '../../assetDataListItem';
 
 const meta: Meta<typeof AssetDataListItem.Skeleton> = {
@@ -18,13 +17,6 @@ type Story = StoryObj<typeof AssetDataListItem.Skeleton>;
 /**
  * Default usage example of the DaoDataListItemSkeleton component.
  */
-export const Default: Story = {
-    args: {},
-    render: () => (
-        <DataList.Root entityLabel="Asset" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={AssetDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.test.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { AssetDataListItem, type IAssetDataListItemSkeletonProps } from '../../assetDataListItem';
 
 describe('<AssetDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IAssetDataListItemSkeletonProps>) => {
         const completeProps: IAssetDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Asset">
-                <AssetDataListItem.Skeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <AssetDataListItem.Skeleton {...completeProps} />;
     };
     it('has correct accessibility attributes', () => {
         render(createTestComponent());

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemSkeleton/assetDataListItemSkeleton.tsx
@@ -4,10 +4,11 @@ import { DataList, type IDataListItemProps } from '../../../../../core';
 import { StateSkeletonBar } from '../../../../../core/components/states/stateSkeletonBar';
 import { StateSkeletonCircular } from '../../../../../core/components/states/stateSkeletonCircular';
 
-export interface IAssetDataListItemSkeletonProps extends IDataListItemProps {}
+export type IAssetDataListItemSkeletonProps = IDataListItemProps;
 
 export const AssetDataListItemSkeleton: React.FC<IAssetDataListItemSkeletonProps> = (props) => {
     const { className, ...otherProps } = props;
+
     return (
         <DataList.Item
             tabIndex={0}

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.stories.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { AssetDataListItemStructure } from './assetDataListItemStructure';
 
 const meta: Meta<typeof AssetDataListItemStructure> = {
@@ -27,13 +26,6 @@ export const Default: Story = {
         fiatPrice: 3654.76,
         priceChange: 15,
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Assets">
-            <DataList.Container>
-                <AssetDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -48,13 +40,6 @@ export const LongName: Story = {
         fiatPrice: 3654.76,
         priceChange: 15,
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Assets">
-            <DataList.Container>
-                <AssetDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -66,13 +51,6 @@ export const Fallback: Story = {
         amount: 420.69,
         symbol: 'ETH',
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Assets">
-            <DataList.Container>
-                <AssetDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.test.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { AssetDataListItemStructure, type IAssetDataListItemStructureProps } from './assetDataListItemStructure';
 
 describe('<AssetDataListItem.Structure /> component', () => {
@@ -11,13 +10,7 @@ describe('<AssetDataListItem.Structure /> component', () => {
             ...props,
         };
 
-        return (
-            <DataList.Root entityLabel="Assets">
-                <DataList.Container>
-                    <AssetDataListItemStructure {...completeProps} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+        return <AssetDataListItemStructure {...completeProps} />;
     };
 
     it('renders token name and symbol', () => {

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { Avatar, DataList, NumberFormat, Tag, formatterUtils, type IDataListItemProps } from '../../../../../core';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 
-export interface IAssetDataListItemStructureProps extends IDataListItemProps {
+export type IAssetDataListItemStructureProps = IDataListItemProps & {
     /**
      * The name of the asset.
      */
@@ -30,7 +30,7 @@ export interface IAssetDataListItemStructureProps extends IDataListItemProps {
      * @default 0
      */
     priceChange?: number;
-}
+};
 
 export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructureProps> = (props) => {
     const { logoSrc, name, amount, symbol, fiatPrice, priceChange = 0, ...otherProps } = props;

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { DaoDataListItem } from '../../daoDataListItem';
 
 const meta: Meta<typeof DaoDataListItem.Skeleton> = {
@@ -18,13 +17,6 @@ type Story = StoryObj<typeof DaoDataListItem.Skeleton>;
 /**
  * Default usage example of the DaoDataListItemSkeleton component.
  */
-export const Default: Story = {
-    args: {},
-    render: () => (
-        <DataList.Root entityLabel="DAO" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={DaoDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.test.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { DaoDataListItem, type IDaoDataListItemSkeletonProps } from '../../daoDataListItem';
 
 describe('<DaoDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IDaoDataListItemSkeletonProps>) => {
         const completeProps: IDaoDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Proposal">
-                <DaoDataListItem.Skeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <DaoDataListItem.Skeleton {...completeProps} />;
     };
     it('has correct accessibility attributes', () => {
         render(createTestComponent());

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemSkeleton/daoDataListItemSkeleton.tsx
@@ -1,19 +1,13 @@
-import classNames from 'classnames';
 import type React from 'react';
-import { DataList, StateSkeletonBar, StateSkeletonCircular, type IDataListItemProps } from '../../../../../core';
+import { DataList, type IDataListItemProps, StateSkeletonBar, StateSkeletonCircular } from '../../../../../core';
 
-export interface IDaoDataListItemSkeletonProps extends IDataListItemProps {}
+export type IDaoDataListItemSkeletonProps = IDataListItemProps;
 
 export const DaoDataListItemSkeleton: React.FC<IDaoDataListItemSkeletonProps> = (props) => {
     const { className, ...otherProps } = props;
+
     return (
-        <DataList.Item
-            tabIndex={0}
-            aria-busy="true"
-            aria-label="loading"
-            className={classNames('flex flex-col gap-y-4 bg-neutral-0 py-3 md:py-3.5', className)}
-            {...otherProps}
-        >
+        <DataList.Item tabIndex={0} aria-busy="true" aria-label="loading" {...otherProps}>
             <div className="grid gap-y-5 py-1.5">
                 <div className="flex w-full justify-between space-x-4">
                     <div className="grid w-full gap-y-3 text-neutral-800 md:w-2/3 md:gap-y-2">

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.stories.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { DaoDataListItemStructure } from './daoDataListItemStructure';
 
 const meta: Meta<typeof DaoDataListItemStructure> = {
@@ -28,13 +27,6 @@ export const Default: Story = {
         network: 'Ethereum Mainnet',
         ens: 'patito.dao.eth',
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Daos">
-            <DataList.Container>
-                <DaoDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /* Usage with extra long strings for name & ENS */
@@ -48,13 +40,6 @@ export const LongNames: Story = {
         network: 'Ethereum Mainnet',
         ens: 'a_dao_with_an_extremely_long_ens_name_that_should_be_truncated.dao.eth',
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Daos">
-            <DataList.Container>
-                <DaoDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -69,13 +54,6 @@ export const Fallback: Story = {
         network: 'Ethereum Mainnet',
         ens: 'patito.dao.eth',
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Daos">
-            <DataList.Container>
-                <DaoDataListItemStructure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.test.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.test.tsx
@@ -1,16 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { DaoDataListItemStructure, type IDaoDataListItemStructureProps } from './daoDataListItemStructure';
 
 describe('<DaoDataListItemStructure /> component', () => {
     const createTestComponent = (props?: Partial<IDaoDataListItemStructureProps>) => {
-        return (
-            <DataList.Root entityLabel="Daos">
-                <DataList.Container>
-                    <DaoDataListItemStructure {...props} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+        const completeProps: IDaoDataListItemStructureProps = {
+            ...props,
+        };
+
+        return <DaoDataListItemStructure {...completeProps} />;
     };
 
     it('renders ensName and the daoName (in uppercase) as the avatar fallback', () => {

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { DataList, Heading, Icon, IconType, type IDataListItemProps } from '../../../../../core';
 import { DaoAvatar } from '../../daoAvatar';
 
-export interface IDaoDataListItemStructureProps extends IDataListItemProps {
+export type IDaoDataListItemStructureProps = IDataListItemProps & {
     /**
      * The name of the DAO.
      */
@@ -32,7 +32,7 @@ export interface IDaoDataListItemStructureProps extends IDataListItemProps {
      * The network on which the DAO operates.
      */
     network?: string;
-}
+};
 
 export const DaoDataListItemStructure: React.FC<IDaoDataListItemStructureProps> = (props) => {
     const { name, logoSrc, description, network, plugin = 'token-based', address, ens, ...otherProps } = props;

--- a/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { MemberDataListItem } from '../../../..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof MemberDataListItem.Skeleton> = {
     title: 'Modules/Components/Member/MemberDataListItem/MemberDataListItem.Skeleton',
@@ -18,12 +17,6 @@ type Story = StoryObj<typeof MemberDataListItem.Skeleton>;
 /**
  * Default usage example of the MemberDataListItemSkeleton component.
  */
-export const Default: Story = {
-    render: () => (
-        <DataList.Root entityLabel="Proposal" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={MemberDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.test.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { MemberDataListItemSkeleton, type IMemberDataListItemSkeletonProps } from './memberDataListItemSkeleton';
 
 describe('<MemberDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IMemberDataListItemSkeletonProps>) => {
         const completeProps: IMemberDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Member">
-                <MemberDataListItemSkeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <MemberDataListItemSkeleton {...completeProps} />;
     };
 
     it('has correct accessibility attributes', () => {

--- a/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemSkeleton/memberDataListItemSkeleton.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { DataList, StateSkeletonBar, StateSkeletonCircular, type IDataListItemProps } from '../../../../../core';
 
-export interface IMemberDataListItemSkeletonProps extends IDataListItemProps {}
+export type IMemberDataListItemSkeletonProps = IDataListItemProps;
 
 export const MemberDataListItemSkeleton: React.FC<IMemberDataListItemSkeletonProps> = (props) => {
     const { className, ...otherProps } = props;

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.stories.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { MemberDataListItemStructure } from './memberDataListItemStructure';
 
 const meta: Meta<typeof MemberDataListItemStructure> = {
@@ -22,13 +21,6 @@ export const Default: Story = {
     args: {
         address: '0x1234567890123456789012345678901234567890',
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Members">
-            <DataList.Container>
-                <MemberDataListItemStructure {...args} />
-            </DataList.Container>{' '}
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -39,13 +31,6 @@ export const TokenMemberWithoutVotingPower: Story = {
         address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
         tokenAmount: 0,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Members">
-            <DataList.Container>
-                <MemberDataListItemStructure {...args} />
-            </DataList.Container>{' '}
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -57,13 +42,6 @@ export const TokenMemberWithVotingPower: Story = {
         delegationCount: 0,
         tokenAmount: 4820,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Members">
-            <DataList.Container>
-                <MemberDataListItemStructure {...args} />
-            </DataList.Container>{' '}
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -78,13 +56,6 @@ export const Complete: Story = {
         tokenAmount: 13370,
         tokenSymbol: 'PDC',
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Members">
-            <DataList.Container>
-                <MemberDataListItemStructure {...args} />
-            </DataList.Container>{' '}
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.test.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.test.tsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import * as wagmi from 'wagmi';
-import { DataList } from '../../../../../core';
 import { MemberDataListItemStructure, type IMemberDataListItemProps } from './memberDataListItemStructure';
 
 jest.mock('../../memberAvatar', () => ({ MemberAvatar: () => <div data-testid="member-avatar-mock" /> }));
@@ -23,13 +22,7 @@ describe('<MemberDataListItem /> component', () => {
             ...props,
         };
 
-        return (
-            <DataList.Root entityLabel="Members">
-                <DataList.Container>
-                    <MemberDataListItemStructure {...completeProps} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+        return <MemberDataListItemStructure {...completeProps} />;
     };
 
     it('renders the member avatar', () => {

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
@@ -5,7 +5,7 @@ import { addressUtils } from '../../../../utils';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { MemberAvatar } from '../../memberAvatar';
 
-export interface IMemberDataListItemProps extends IDataListItemProps {
+export type IMemberDataListItemProps = IDataListItemProps & {
     /**
      * Whether the member is a delegate of current user or not.
      */
@@ -38,7 +38,7 @@ export interface IMemberDataListItemProps extends IDataListItemProps {
      * Token Symbol.
      */
     tokenSymbol?: string;
-}
+};
 
 export const MemberDataListItemStructure: React.FC<IMemberDataListItemProps> = (props) => {
     const {

--- a/src/modules/components/proposal/proposalActions/actions/generators/proposalActionTokenMint.ts
+++ b/src/modules/components/proposal/proposalActions/actions/generators/proposalActionTokenMint.ts
@@ -10,7 +10,7 @@ export const generateProposalActionTokenMint = (
     data: '',
     value: '0',
     inputData: {
-        function: 'Mint tokens',
+        function: 'mint',
         contract: 'GovernanceERC20',
         parameters: [
             { name: 'address', type: 'string', value: '0x3f5CE5FBFe3E9af3971dD833D26BA9b5C936F0bE' },

--- a/src/modules/components/proposal/proposalActions/actions/generators/proposalActionUpdateMetadata.ts
+++ b/src/modules/components/proposal/proposalActions/actions/generators/proposalActionUpdateMetadata.ts
@@ -8,7 +8,7 @@ export const generateProposalActionUpdateMetadata = (
     data: '',
     value: '0',
     inputData: {
-        function: 'Update DAO metadata',
+        function: 'setMetadata',
         contract: 'DAO',
         parameters: [
             { name: 'address', type: 'string', value: '0x3f5CE5FBFe3E9af3971dD833D26BA9b5C936F0bE' },

--- a/src/modules/components/proposal/proposalActions/actions/proposalActionChangeMembers/proposalActionChangeMembers.stories.tsx
+++ b/src/modules/components/proposal/proposalActions/actions/proposalActionChangeMembers/proposalActionChangeMembers.stories.tsx
@@ -17,25 +17,23 @@ const meta: Meta<typeof ProposalActionChangeMembers> = {
 type Story = StoryObj<typeof ProposalActionChangeMembers>;
 
 /**
- * Usage example of the ProposalActions module component with mocked ChangeMembers action. @default ProposalActionType.ADD_MEMBERS
+ * Usage example of the ProposalActions module component with mocked ChangeMembers action.
  */
 export const Default: Story = {
-    render: () => {
-        return <ProposalActionChangeMembers action={generateProposalActionChangeMembers()} />;
+    args: {
+        action: generateProposalActionChangeMembers(),
     },
 };
 
 export const RemoveMembers: Story = {
-    render: () => {
-        const action = generateProposalActionChangeMembers({
+    args: {
+        action: generateProposalActionChangeMembers({
             type: ProposalActionType.REMOVE_MEMBERS,
             members: [
-                {
-                    address: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-                },
+                { address: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e' },
+                { address: '0x8C8D7C46219D9205f056f28fee5950aD564d7465' },
             ],
-        });
-        return <ProposalActionChangeMembers action={action} />;
+        }),
     },
 };
 

--- a/src/modules/components/proposal/proposalActions/actions/proposalActionChangeMembers/proposalActionChangeMembers.tsx
+++ b/src/modules/components/proposal/proposalActions/actions/proposalActionChangeMembers/proposalActionChangeMembers.tsx
@@ -1,4 +1,4 @@
-import { DataList, DefinitionList, Heading } from '../../../../../../core';
+import { DefinitionList, Heading } from '../../../../../../core';
 import { MemberDataListItem } from '../../../../member';
 import { useOdsModulesContext } from '../../../../odsModulesProvider';
 import { ProposalActionType, type IProposalActionChangeMembers } from '../../proposalActionsTypes';
@@ -16,18 +16,16 @@ export const ProposalActionChangeMembers: React.FC<IProposalActionChangeMembersP
 
     return (
         <div className="flex flex-col gap-y-6">
-            <DataList.Root entityLabel="Members">
-                <DataList.Container>
-                    {action.members.map((member) => (
-                        <MemberDataListItem.Structure
-                            key={member.address}
-                            address={member.address}
-                            ensName={member.name}
-                            avatarSrc={member.avatarSrc}
-                        />
-                    ))}
-                </DataList.Container>
-            </DataList.Root>
+            <div className="flex flex-col gap-2 md:flex-row">
+                {action.members.map((member) => (
+                    <MemberDataListItem.Structure
+                        key={member.address}
+                        address={member.address}
+                        ensName={member.name}
+                        avatarSrc={member.avatarSrc}
+                    />
+                ))}
+            </div>
             <div>
                 <Heading size="h3">{copy.proposalActionChangeMembers.summary}</Heading>
                 <DefinitionList.Container>

--- a/src/modules/components/proposal/proposalActions/actions/proposalActionTokenMint/proposalActionTokenMint.tsx
+++ b/src/modules/components/proposal/proposalActions/actions/proposalActionTokenMint/proposalActionTokenMint.tsx
@@ -1,4 +1,3 @@
-import { DataList } from '../../../../../../core';
 import { MemberDataListItemStructure } from '../../../../member';
 import { type IProposalActionComponentProps, type IProposalActionTokenMint } from '../../proposalActionsTypes';
 
@@ -13,19 +12,15 @@ export const ProposalActionTokenMint: React.FC<IProposalActionTokenMintProps> = 
 
     return (
         <div className="flex w-full flex-col gap-8">
-            <DataList.Root entityLabel="proposalActionTokenMintReceivers">
-                <DataList.Container>
-                    <MemberDataListItemStructure
-                        className="w-full"
-                        address={address}
-                        ensName={name}
-                        avatarSrc={avatarSrc}
-                        tokenAmount={mintedTokenAmount}
-                        tokenSymbol={tokenSymbol}
-                        hideLabelTokenVoting={true}
-                    />
-                </DataList.Container>
-            </DataList.Root>
+            <MemberDataListItemStructure
+                className="w-full"
+                address={address}
+                ensName={name}
+                avatarSrc={avatarSrc}
+                tokenAmount={mintedTokenAmount}
+                tokenSymbol={tokenSymbol}
+                hideLabelTokenVoting={true}
+            />
         </div>
     );
 };

--- a/src/modules/components/proposal/proposalActions/proposalActions/index.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActions/index.ts
@@ -1,1 +1,2 @@
-export { ProposalActions, type IProposalActionsProps } from './proposalActions';
+export { ProposalActions } from './proposalActions';
+export type { IProposalActionsDropdownItem, IProposalActionsProps } from './proposalActions.api';

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
@@ -3,7 +3,7 @@ import type { IconType } from '../../../../../core';
 import type { IWeb3ComponentProps } from '../../../../types';
 import type { IProposalAction, ProposalActionComponent } from '../proposalActionsTypes';
 
-export interface IProposalActionsDropdownItem {
+export interface IProposalActionsDropdownItem<TAction extends IProposalAction = IProposalAction> {
     /**
      * Label of the item.
      */
@@ -15,14 +15,14 @@ export interface IProposalActionsDropdownItem {
     /**
      * Callback called with the current action on item click.
      */
-    onClick: (action: IProposalAction) => void;
+    onClick: (action: TAction) => void;
 }
 
-export interface IProposalActionsProps extends IWeb3ComponentProps {
+export interface IProposalActionsProps<TAction extends IProposalAction = IProposalAction> extends IWeb3ComponentProps {
     /**
      * Actions to render.
      */
-    actions: IProposalAction[];
+    actions: TAction[];
     /**
      * Map of action-type <=> action-name displayed on the action header.
      */
@@ -30,7 +30,7 @@ export interface IProposalActionsProps extends IWeb3ComponentProps {
     /**
      * Map of action-type <=> custom-component to customize how actions are displayed.
      */
-    customActionComponents?: Record<string, ProposalActionComponent>;
+    customActionComponents?: Record<string, ProposalActionComponent<TAction>>;
     /**
      * Custom description for the empty state.
      */
@@ -38,7 +38,7 @@ export interface IProposalActionsProps extends IWeb3ComponentProps {
     /**
      * Items to be displayed insdie a dropdown for each proposal action (e.g. remove from list, move up, etc..)
      */
-    dropdownItems?: IProposalActionsDropdownItem[];
+    dropdownItems?: Array<IProposalActionsDropdownItem<TAction>>;
     /**
      * Additional classes for the component.
      */

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import type { IconType } from '../../../../../core';
+import type { IWeb3ComponentProps } from '../../../../types';
+import type { IProposalAction, ProposalActionComponent } from '../proposalActionsTypes';
+
+export interface IProposalActionsDropdownItem {
+    /**
+     * Label of the item.
+     */
+    label: string;
+    /**
+     * Icon of the item.
+     */
+    icon: IconType;
+    /**
+     * Callback called with the current action on item click.
+     */
+    onClick: (action: IProposalAction) => void;
+}
+
+export interface IProposalActionsProps extends IWeb3ComponentProps {
+    /**
+     * Actions to render.
+     */
+    actions: IProposalAction[];
+    /**
+     * Map of action-type <=> action-name displayed on the action header.
+     */
+    actionNames?: Record<string, string>;
+    /**
+     * Map of action-type <=> custom-component to customize how actions are displayed.
+     */
+    customActionComponents?: Record<string, ProposalActionComponent>;
+    /**
+     * Custom description for the empty state.
+     */
+    emptyStateDescription: string;
+    /**
+     * Items to be displayed insdie a dropdown for each proposal action (e.g. remove from list, move up, etc..)
+     */
+    dropdownItems?: IProposalActionsDropdownItem[];
+    /**
+     * Additional classes for the component.
+     */
+    className?: string;
+    /**
+     * Children of the component.
+     */
+    children?: ReactNode;
+}

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.api.ts
@@ -36,7 +36,7 @@ export interface IProposalActionsProps<TAction extends IProposalAction = IPropos
      */
     emptyStateDescription: string;
     /**
-     * Items to be displayed insdie a dropdown for each proposal action (e.g. remove from list, move up, etc..)
+     * Items to be displayed inside a dropdown for each proposal action (e.g. remove from list, move up, etc..)
      */
     dropdownItems?: Array<IProposalActionsDropdownItem<TAction>>;
     /**

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.stories.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
-import { Button } from '../../../../../core';
+import { Button, IconType } from '../../../../../core';
 import {
     generateProposalAction,
+    generateProposalActionTokenMint,
     generateProposalActionUpdateMetadata,
     generateProposalActionWithdrawToken,
     generateToken,
@@ -28,7 +28,6 @@ type Story = StoryObj<typeof ProposalActions>;
  */
 export const MixedActions: Story = {
     args: {
-        actionNames: { WITHDRAW_TOKEN: 'Withdraw assets', ADD_MEMBERS: 'Add members' },
         actions: [
             generateProposalActionWithdrawToken({
                 to: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
@@ -103,7 +102,7 @@ export const CustomActions: Story = {
                 inputData: { function: 'doSomething', contract: 'Ether', parameters: [] },
                 from: '0x1111111111111111111111111111111111111111',
                 to: '0x2222222222222222222222222222222222222222',
-                data: '',
+                data: '0x',
                 value: '10',
             },
             {
@@ -111,7 +110,7 @@ export const CustomActions: Story = {
                 inputData: { function: 'doSomethingElse', contract: 'DAI', parameters: [] },
                 from: '0x3333333333333333333333333333333333333333',
                 to: '0x4444444444444444444444444444444444444444',
-                data: '',
+                data: '0x',
                 value: '20',
             },
         ];
@@ -120,9 +119,7 @@ export const CustomActions: Story = {
             <ProposalActions
                 actions={actions}
                 actionNames={actionNames}
-                customActionComponents={{
-                    CUSTOM_ACTION: CustomActionComponent,
-                }}
+                customActionComponents={{ CUSTOM_ACTION: CustomActionComponent }}
                 emptyStateDescription="No actions added. Consider adding some."
             />
         );
@@ -138,27 +135,25 @@ export const EmptyActions: Story = {
 
 export const WithChildren: Story = {
     args: {
-        actionNames: { WITHDRAW_TOKEN: 'Withdraw assets', ADD_MEMBERS: 'Add members' },
-        actions: [
-            generateProposalActionWithdrawToken({
-                to: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-                value: '1000000000000000000',
-                data: '0x',
-                token: generateToken({
-                    name: 'Ether',
-                    symbol: 'ETH',
-                    logo: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
-                    priceUsd: '2800',
-                }),
-            }),
-            generateProposalActionUpdateMetadata({ data: 'update-data' }),
-        ],
+        actions: [generateProposalActionWithdrawToken(), generateProposalActionUpdateMetadata()],
     },
     render: (args) => (
         <ProposalActions {...args}>
             <Button size="md">Confirm Actions</Button>
         </ProposalActions>
     ),
+};
+
+export const WithDropdownItems: Story = {
+    args: {
+        actions: [generateProposalActionUpdateMetadata(), generateProposalActionTokenMint()],
+        dropdownItems: [
+            { label: 'Move up', icon: IconType.CHEVRON_UP, onClick: () => null },
+            { label: 'Move down', icon: IconType.CHEVRON_DOWN, onClick: () => null },
+            { label: 'Reset action', icon: IconType.RELOAD, onClick: () => null },
+            { label: 'Remove action', icon: IconType.CLOSE, onClick: () => null },
+        ],
+    },
 };
 
 export default meta;

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.test.tsx
@@ -5,7 +5,8 @@ import { OdsModulesProvider } from '../../../odsModulesProvider';
 import { generateProposalAction } from '../actions/generators/proposalAction';
 import { generateProposalActionWithdrawToken } from '../actions/generators/proposalActionWithdrawToken';
 import { ProposalActionType, type IProposalAction } from '../proposalActionsTypes';
-import { ProposalActions, type IProposalActionsProps } from './proposalActions';
+import { ProposalActions } from './proposalActions';
+import type { IProposalActionsProps } from './proposalActions.api';
 
 jest.mock('../../../member', () => ({ MemberAvatar: () => <div data-testid="member-avatar" /> }));
 

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
@@ -1,41 +1,21 @@
 import classNames from 'classnames';
-import { useRef, useState, type ReactNode } from 'react';
+import { useRef, useState } from 'react';
 import { Accordion, Button, Card, EmptyState } from '../../../../../core';
-import type { IWeb3ComponentProps } from '../../../../types';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { ProposalActionsAction } from '../proposalActionsAction';
-import type { IProposalAction, ProposalActionComponent } from '../proposalActionsTypes';
-
-export interface IProposalActionsProps extends IWeb3ComponentProps {
-    /**
-     * Actions to render.
-     */
-    actions: IProposalAction[];
-    /**
-     * Map of action-type <=> action-name displayed on the action header.
-     */
-    actionNames?: Record<string, string>;
-    /**
-     * Map of action-type <=> custom-component to customize how actions are displayed.
-     */
-    customActionComponents?: Record<string, ProposalActionComponent>;
-    /**
-     * Additional classes for the component.
-     */
-    className?: string;
-    /**
-     * Children of the component.
-     */
-    children?: ReactNode;
-    /**
-     * Custom description for the empty state.
-     */
-    emptyStateDescription: string;
-}
+import type { IProposalActionsProps } from './proposalActions.api';
 
 export const ProposalActions: React.FC<IProposalActionsProps> = (props) => {
-    const { actions, actionNames, className, customActionComponents, children, emptyStateDescription, ...web3Props } =
-        props;
+    const {
+        actions,
+        actionNames,
+        customActionComponents,
+        emptyStateDescription,
+        dropdownItems,
+        className,
+        children,
+        ...web3Props
+    } = props;
 
     const [expandedItems, setExpandedItems] = useState<string[]>(['0']);
 
@@ -77,6 +57,7 @@ export const ProposalActions: React.FC<IProposalActionsProps> = (props) => {
                         index={index}
                         name={actionNames?.[action.type]}
                         CustomComponent={customActionComponents?.[action.type]}
+                        dropdownItems={dropdownItems}
                         {...web3Props}
                     />
                 ))}

--- a/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActions/proposalActions.tsx
@@ -3,9 +3,12 @@ import { useRef, useState } from 'react';
 import { Accordion, Button, Card, EmptyState } from '../../../../../core';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { ProposalActionsAction } from '../proposalActionsAction';
+import type { IProposalAction } from '../proposalActionsTypes';
 import type { IProposalActionsProps } from './proposalActions.api';
 
-export const ProposalActions: React.FC<IProposalActionsProps> = (props) => {
+export const ProposalActions = <TAction extends IProposalAction = IProposalAction>(
+    props: IProposalActionsProps<TAction>,
+) => {
     const {
         actions,
         actionNames,

--- a/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.test.tsx
@@ -127,4 +127,28 @@ describe('<ProposalActionsAction /> component', () => {
         await userEvent.click(screen.getByRole('button'));
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
+
+    it('renders the dropdown with the specified items when the dropdownItems property is set', async () => {
+        const dropdownItems = [
+            { label: 'Select', icon: IconType.APP_ASSETS, onClick: jest.fn() },
+            { label: 'Edit', icon: IconType.APP_TRANSACTIONS, onClick: jest.fn() },
+        ];
+        const action = generateProposalAction();
+        render(createTestComponent({ dropdownItems, action }));
+
+        await userEvent.click(screen.getByRole('button'));
+        const dropdownTrigger = screen.getByRole('button', { name: modulesCopy.proposalActionsAction.dropdownLabel });
+        expect(dropdownTrigger).toBeInTheDocument();
+        await userEvent.click(dropdownTrigger);
+
+        const dropdownItem = screen.getByRole('menuitem', { name: dropdownItems[0].label });
+        expect(dropdownItem).toBeInTheDocument();
+        expect(screen.getByTestId(dropdownItems[0].icon)).toBeInTheDocument();
+
+        expect(screen.getByRole('menuitem', { name: dropdownItems[1].label })).toBeInTheDocument();
+        expect(screen.getByTestId(dropdownItems[1].icon)).toBeInTheDocument();
+
+        await userEvent.click(dropdownItem);
+        expect(dropdownItems[0].onClick).toHaveBeenCalledWith(action);
+    });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
@@ -20,11 +20,12 @@ import { ProposalActionsActionDecodedView } from './proposalActionsActionDecoded
 import { ProposalActionsActionRawView } from './proposalActionsActionRawView';
 import { ProposalActionsActionViewAsMenu } from './proposalActionsActionViewAsMenu';
 
-export interface IProposalActionsActionProps extends IWeb3ComponentProps {
+export interface IProposalActionsActionProps<TAction extends IProposalAction = IProposalAction>
+    extends IWeb3ComponentProps {
     /**
      * Proposal action
      */
-    action: IProposalAction;
+    action: TAction;
     /**
      * Proposal action name
      */
@@ -36,14 +37,16 @@ export interface IProposalActionsActionProps extends IWeb3ComponentProps {
     /**
      * Custom component for the action
      */
-    CustomComponent?: ProposalActionComponent;
+    CustomComponent?: ProposalActionComponent<TAction>;
     /**
      * Items displayed beside the "View as" menu.
      */
-    dropdownItems?: IProposalActionsDropdownItem[];
+    dropdownItems?: Array<IProposalActionsDropdownItem<TAction>>;
 }
 
-export const ProposalActionsAction: React.FC<IProposalActionsActionProps> = (props) => {
+export const ProposalActionsAction = <TAction extends IProposalAction = IProposalAction>(
+    props: IProposalActionsActionProps<TAction>,
+) => {
     const { action, index, name, CustomComponent, dropdownItems, ...web3Props } = props;
 
     const { copy } = useOdsModulesContext();

--- a/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsAction/proposalActionsAction.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
-import { Accordion, AlertCard, Heading, Icon, IconType } from '../../../../../core';
+import { Accordion, AlertCard, Button, Dropdown, Heading, Icon, IconType } from '../../../../../core';
 import type { IWeb3ComponentProps } from '../../../../types';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import {
@@ -11,6 +11,7 @@ import {
 } from '../actions';
 
 import { formatUnits } from 'viem';
+import type { IProposalActionsDropdownItem } from '../proposalActions';
 import { ProposalActionsActionVerification } from '../proposalActionsActionVerification';
 import type { IProposalAction, ProposalActionComponent } from '../proposalActionsTypes';
 import { ProposalActionViewMode } from '../proposalActionsTypes';
@@ -36,10 +37,14 @@ export interface IProposalActionsActionProps extends IWeb3ComponentProps {
      * Custom component for the action
      */
     CustomComponent?: ProposalActionComponent;
+    /**
+     * Items displayed beside the "View as" menu.
+     */
+    dropdownItems?: IProposalActionsDropdownItem[];
 }
 
 export const ProposalActionsAction: React.FC<IProposalActionsActionProps> = (props) => {
-    const { action, index, name, CustomComponent, ...web3Props } = props;
+    const { action, index, name, CustomComponent, dropdownItems, ...web3Props } = props;
 
     const { copy } = useOdsModulesContext();
 
@@ -127,12 +132,34 @@ export const ProposalActionsAction: React.FC<IProposalActionsActionProps> = (pro
                     )}
                     {viewMode === ProposalActionViewMode.RAW && <ProposalActionsActionRawView action={action} />}
 
-                    <ProposalActionsActionViewAsMenu
-                        disableBasic={ActionComponent == null}
-                        disableDecoded={action.inputData == null}
-                        viewMode={viewMode}
-                        onViewModeChange={onViewModeChange}
-                    />
+                    <div className="flex w-full flex-row justify-between">
+                        <ProposalActionsActionViewAsMenu
+                            disableBasic={ActionComponent == null}
+                            disableDecoded={action.inputData == null}
+                            viewMode={viewMode}
+                            onViewModeChange={onViewModeChange}
+                        />
+                        {dropdownItems != null && dropdownItems.length > 0 && (
+                            <Dropdown.Container
+                                customTrigger={
+                                    <Button variant="tertiary" size="sm" iconRight={IconType.DOTS_VERTICAL}>
+                                        {copy.proposalActionsAction.dropdownLabel}
+                                    </Button>
+                                }
+                            >
+                                {dropdownItems.map((item) => (
+                                    <Dropdown.Item
+                                        key={item.label}
+                                        icon={item.icon}
+                                        iconPosition="left"
+                                        onClick={() => item.onClick?.(action)}
+                                    >
+                                        {item.label}
+                                    </Dropdown.Item>
+                                ))}
+                            </Dropdown.Container>
+                        )}
+                    </div>
                 </div>
             </Accordion.ItemContent>
         </Accordion.Item>

--- a/src/modules/components/proposal/proposalActions/proposalActionsTypes/proposalActionComponent.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsTypes/proposalActionComponent.ts
@@ -2,11 +2,14 @@ import type { ComponentType } from 'react';
 import type { IWeb3ComponentProps } from '../../../../types';
 import type { IProposalAction } from './proposalAction';
 
-export interface IProposalActionComponentProps<TAction = IProposalAction> extends IWeb3ComponentProps {
+export interface IProposalActionComponentProps<TAction extends IProposalAction = IProposalAction>
+    extends IWeb3ComponentProps {
     /**
      * Action to be rendered.
      */
     action: TAction;
 }
 
-export type ProposalActionComponent<TAction = IProposalAction> = ComponentType<IProposalActionComponentProps<TAction>>;
+export type ProposalActionComponent<TAction extends IProposalAction = IProposalAction> = ComponentType<
+    IProposalActionComponentProps<TAction>
+>;

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList, ProposalDataListItem } from '../../../../..';
+import { ProposalDataListItem } from '../../../../..';
 
 const meta: Meta<typeof ProposalDataListItem.Skeleton> = {
     title: 'Modules/Components/Proposal/ProposalDataListItem/ProposalDataListItem.Skeleton',
@@ -17,13 +17,6 @@ type Story = StoryObj<typeof ProposalDataListItem.Skeleton>;
 /**
  * Default usage example of the ProposalDataListItemStructureSkeleton component.
  */
-export const Default: Story = {
-    args: {},
-    render: () => (
-        <DataList.Root entityLabel="Proposal" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={ProposalDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.test.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { ProposalDataListItemSkeleton, type IProposalDataListItemSkeletonProps } from './proposalDataListItemSkeleton';
 
 describe('<ProposalDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IProposalDataListItemSkeletonProps>) => {
         const completeProps: IProposalDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Proposal">
-                <ProposalDataListItemSkeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <ProposalDataListItemSkeleton {...completeProps} />;
     };
     it('has correct accessibility attributes', () => {
         render(createTestComponent());

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import type React from 'react';
 import { DataList, StateSkeletonBar, type IDataListItemProps } from '../../../../../core';
 
-export interface IProposalDataListItemSkeletonProps extends IDataListItemProps {}
+export type IProposalDataListItemSkeletonProps = IDataListItemProps;
 
 export const ProposalDataListItemSkeleton: React.FC<IProposalDataListItemSkeletonProps> = (props) => {
     const { className, ...otherProps } = props;
@@ -19,14 +19,14 @@ export const ProposalDataListItemSkeleton: React.FC<IProposalDataListItemSkeleto
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="16%" />
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="24%" />
             </div>
-            <div className="flex flex-col gap-y-2">
+            <div className="flex w-full flex-col gap-y-2">
                 <StateSkeletonBar size="xl" width="72%" />
                 <div className="flex flex-col gap-y-1 md:gap-y-2">
                     <StateSkeletonBar size="lg" width="100%" />
                     <StateSkeletonBar size="lg" width="64%" />
                 </div>
             </div>
-            <div className="flex justify-between">
+            <div className="flex w-full justify-between">
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="20%" />
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="16%" />
             </div>

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemSkeleton/proposalDataListItemSkeleton.tsx
@@ -15,7 +15,7 @@ export const ProposalDataListItemSkeleton: React.FC<IProposalDataListItemSkeleto
             className={classNames('flex flex-col gap-y-4 bg-neutral-0 py-4 md:py-5', className)}
             {...otherProps}
         >
-            <div className="flex justify-between">
+            <div className="flex w-full justify-between">
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="16%" />
                 <StateSkeletonBar size="lg" responsiveSize={{ md: 'xl' }} width="24%" />
             </div>

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStatus/proposalDataListItemStatus.tsx
@@ -43,14 +43,14 @@ export const ProposalDataListItemStatus: React.FC<IProposalDataListItemStatusPro
     const { copy } = useOdsModulesContext();
 
     return (
-        <div className="flex items-center gap-x-4 md:gap-x-6">
+        <div className="flex w-full items-center justify-between gap-x-4 md:gap-x-6">
             <Tag
                 label={copy.proposalDataListItemStatus.statusLabel[status]}
                 variant={proposalStatusToTagVariant[status]}
                 className="shrink-0"
             />
             {showStatusMetadata && (
-                <div className="flex flex-1 items-center justify-end gap-x-2 md:gap-x-3">
+                <div className="flex items-center gap-x-2 md:gap-x-3">
                     <span
                         className={classNames('text-sm leading-tight md:text-base', {
                             'text-info-800': status === ProposalStatus.ACTIVE,

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
@@ -4,50 +4,49 @@ import { type ProposalStatus } from '../../proposalUtils';
 
 export type ProposalType = 'majorityVoting' | 'approvalThreshold';
 
-export interface IProposalDataListItemStructureBaseProps<TType extends ProposalType = ProposalType>
-    extends IDataListItemProps,
-        IWeb3ComponentProps {
-    /**
-     * Proposal id
-     */
-    id?: string;
-    /**
-     *  Date relative to the proposal status in ISO format or as a timestamp
-     */
-    date?: string | number;
-    /**
-     * Optional tag indicating proposal type
-     */
-    tag?: string;
-    /**
-     * Publisher(s) address (and optional ENS name and profile link)
-     */
-    publisher: IPublisher | IPublisher[];
-    /**
-     * Result of the proposal shown only when it is active, challenged or vetoed.
-     */
-    result?: TType extends 'majorityVoting' ? IMajorityVotingResult : IApprovalThresholdResult;
-    /**
-     * Proposal status
-     */
-    status: ProposalStatus;
-    /**
-     * Proposal description
-     */
-    summary: string;
-    /**
-     * Proposal title
-     */
-    title: string;
-    /**
-     * Type of the ProposalDataListItem
-     */
-    type: TType;
-    /**
-     * Indicates whether the connected wallet has voted
-     */
-    voted?: boolean;
-}
+export type IProposalDataListItemStructureBaseProps<TType extends ProposalType = ProposalType> = IDataListItemProps &
+    IWeb3ComponentProps & {
+        /**
+         * Proposal id
+         */
+        id?: string;
+        /**
+         *  Date relative to the proposal status in ISO format or as a timestamp
+         */
+        date?: string | number;
+        /**
+         * Optional tag indicating proposal type
+         */
+        tag?: string;
+        /**
+         * Publisher(s) address (and optional ENS name and profile link)
+         */
+        publisher: IPublisher | IPublisher[];
+        /**
+         * Result of the proposal shown only when it is active, challenged or vetoed.
+         */
+        result?: TType extends 'majorityVoting' ? IMajorityVotingResult : IApprovalThresholdResult;
+        /**
+         * Proposal status
+         */
+        status: ProposalStatus;
+        /**
+         * Proposal description
+         */
+        summary: string;
+        /**
+         * Proposal title
+         */
+        title: string;
+        /**
+         * Type of the ProposalDataListItem
+         */
+        type: TType;
+        /**
+         * Indicates whether the connected wallet has voted
+         */
+        voted?: boolean;
+    };
 
 export interface IPublisher extends ICompositeAddress {
     /**

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { ProposalDataListItem, ProposalStatus } from '../../index';
 import { type IProposalDataListItemStructureProps } from './proposalDataListItemStructure.api';
 
@@ -47,13 +46,6 @@ export const MajorityVoting: Story = {
             votePercentage: 15,
         },
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Proposals">
-            <DataList.Container>
-                <ProposalDataListItem.Structure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -69,13 +61,6 @@ export const ApprovalThreshold: Story = {
             approvalThreshold: 6,
         },
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Proposals">
-            <DataList.Container>
-                <ProposalDataListItem.Structure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -98,13 +83,6 @@ export const MultiBody: Story = {
             approvalThreshold: 6,
         },
     },
-    render: (props) => (
-        <DataList.Root entityLabel="Proposals">
-            <DataList.Container SkeletonElement={ProposalDataListItem.Skeleton}>
-                <ProposalDataListItem.Structure {...props} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.test.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { DateTime } from 'luxon';
 import * as wagmi from 'wagmi';
-import { DataList } from '../../../../../core';
 import { modulesCopy } from '../../../../assets';
 import { addressUtils } from '../../../../utils/addressUtils';
 import { ProposalStatus } from '../../proposalUtils';
@@ -54,18 +53,10 @@ describe('<ProposalDataListItemStructure/> component', () => {
         };
 
         if (baseProps.type === 'approvalThreshold') {
-            return (
-                <DataList.Root entityLabel="Proposals">
-                    <ProposalDataListItemStructure {...baseProps} result={approvalResult} type="approvalThreshold" />
-                </DataList.Root>
-            );
+            return <ProposalDataListItemStructure {...baseProps} result={approvalResult} type="approvalThreshold" />;
         }
 
-        return (
-            <DataList.Root entityLabel="Proposals">
-                <ProposalDataListItemStructure {...baseProps} result={majorityVotingProps} type="majorityVoting" />
-            </DataList.Root>
-        );
+        return <ProposalDataListItemStructure {...baseProps} result={majorityVotingProps} type="majorityVoting" />;
     };
 
     it("renders 'You' as the publisher if the connected address is the publisher address", () => {

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { TransactionDataListItem } from '../../../..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof TransactionDataListItem.Skeleton> = {
     title: 'Modules/Components/Transaction/TransactionDataListItem/TransactionDataListItem.Skeleton',
@@ -18,12 +17,6 @@ type Story = StoryObj<typeof TransactionDataListItem.Skeleton>;
 /**
  * Default usage example of the TransactionDataListItem.Skeleton component.
  */
-export const Default: Story = {
-    render: () => (
-        <DataList.Root entityLabel="Transaction" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={TransactionDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.test.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { DataList } from '../../../../../core';
 import { TransactionDataListItem, type ITransactionDataListItemSkeletonProps } from '../../transactionDataListItem';
 
 describe('<MemberDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<ITransactionDataListItemSkeletonProps>) => {
         const completeProps: ITransactionDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Transaction">
-                <TransactionDataListItem.Skeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <TransactionDataListItem.Skeleton {...completeProps} />;
     };
 
     it('has correct accessibility attributes', () => {

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemSkeleton/transactionDataListItemSkeleton.tsx
@@ -1,6 +1,6 @@
 import { DataList, StateSkeletonBar, StateSkeletonCircular, type IDataListItemProps } from '../../../../../core';
 
-export interface ITransactionDataListItemSkeletonProps extends IDataListItemProps {}
+export type ITransactionDataListItemSkeletonProps = IDataListItemProps;
 
 export const TransactionDataListItemSkeleton: React.FC<ITransactionDataListItemSkeletonProps> = (props) => {
     return (

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.api.ts
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.api.ts
@@ -13,7 +13,7 @@ export enum TransactionType {
     ACTION = 'ACTION',
 }
 
-export interface ITransactionDataListItemProps extends IDataListItemProps {
+export type ITransactionDataListItemProps = IDataListItemProps & {
     /**
      * The chain ID of the transaction.
      */
@@ -52,4 +52,4 @@ export interface ITransactionDataListItemProps extends IDataListItemProps {
      * The transaction hash.
      */
     hash: Hash;
-}
+};

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.stories.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DataList } from '../../../../../core';
 import { TransactionDataListItemStructure } from './transactionDataListItemStructure';
 import { TransactionStatus, TransactionType } from './transactionDataListItemStructure.api';
 
@@ -24,16 +23,11 @@ type Story = StoryObj<typeof TransactionDataListItemStructure>;
 /**
  * Default usage example of the TransactionDataList module component.
  */
-export const Default: Story = {
-    render: (args) => (
-        <DataList.Root entityLabel="Transactions">
-            <DataList.Container>
-                <TransactionDataListItemStructure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
+/**
+ * Example of the TransactionDataList component with withdraw transaction.
+ */
 export const Withdraw: Story = {
     args: {
         status: TransactionStatus.SUCCESS,
@@ -42,15 +36,11 @@ export const Withdraw: Story = {
         tokenSymbol: 'ETH',
         date: 1613984914000,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Transactions">
-            <DataList.Container>
-                <TransactionDataListItemStructure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
+/**
+ * Example of the TransactionDataList component with failed transaction.
+ */
 export const Failed: Story = {
     args: {
         status: TransactionStatus.FAILED,
@@ -60,13 +50,6 @@ export const Failed: Story = {
         tokenPrice: 100,
         date: 1613984914000,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Transactions">
-            <DataList.Container>
-                <TransactionDataListItemStructure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.test.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import * as wagmi from 'wagmi';
-import { DataList, DateFormat, NumberFormat, formatterUtils } from '../../../../../core';
+import { DateFormat, NumberFormat, formatterUtils } from '../../../../../core';
 import { TransactionDataListItemStructure } from './transactionDataListItemStructure';
 import {
     TransactionStatus,
@@ -19,11 +19,7 @@ describe('<TransactionDataListItem.Structure /> component', () => {
                     default: { name: 'Etherscan', url: 'https://etherscan.io', apiUrl: 'https://api.etherscan.io/api' },
                 },
                 name: 'Chain Name',
-                nativeCurrency: {
-                    decimals: 18,
-                    name: 'Ether',
-                    symbol: 'ETH',
-                },
+                nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
                 rpcUrls: { default: { http: ['https://cloudflare-eth.com'] } },
             },
         ]);
@@ -40,13 +36,8 @@ describe('<TransactionDataListItem.Structure /> component', () => {
             date: '2023-01-01T00:00:00Z',
             ...props,
         };
-        return (
-            <DataList.Root entityLabel="Transactions">
-                <DataList.Container>
-                    <TransactionDataListItemStructure {...defaultProps} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+
+        return <TransactionDataListItemStructure {...defaultProps} />;
     };
 
     it('renders the transaction type heading', () => {

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
@@ -43,10 +43,8 @@ export const TransactionDataListItemStructure: React.FC<ITransactionDataListItem
         tokenPrice,
         type = TransactionType.ACTION,
         status = TransactionStatus.PENDING,
-        // TO-DO: implement formatter decision
         date,
         hash,
-        href,
         className,
         ...otherProps
     } = props;
@@ -56,7 +54,7 @@ export const TransactionDataListItemStructure: React.FC<ITransactionDataListItem
     const blockExplorerBaseUrl = matchingChain?.blockExplorers?.default?.url;
     const blockExplorerAssembledHref = blockExplorerBaseUrl ? `${blockExplorerBaseUrl}/tx/${hash}` : undefined;
 
-    const parsedHref = blockExplorerAssembledHref ?? href;
+    const parsedHref = blockExplorerAssembledHref ?? ('href' in otherProps ? otherProps.href : undefined);
 
     const formattedTokenValue = formatterUtils.formatNumber(tokenAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,
@@ -71,12 +69,7 @@ export const TransactionDataListItemStructure: React.FC<ITransactionDataListItem
         type === TransactionType.ACTION || tokenAmount == null ? '-' : `${formattedTokenValue} ${tokenSymbol}`;
 
     return (
-        <DataList.Item
-            className={classNames('px-4 py-0 md:px-6', className)}
-            href={parsedHref}
-            target="_blank"
-            {...otherProps}
-        >
+        <DataList.Item className={classNames('px-4 py-0 md:px-6', className)} href={parsedHref} {...otherProps}>
             <div className="flex w-full justify-between py-3 md:py-4">
                 <div className="flex items-center gap-x-3 md:gap-x-4">
                     {status === TransactionStatus.SUCCESS && (

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { VoteDataListItem } from '..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof VoteDataListItem.Skeleton> = {
     title: 'Modules/Components/Vote/VoteDataListItem/VoteDataListItem.Skeleton',
@@ -18,12 +17,6 @@ type Story = StoryObj<typeof VoteDataListItem.Skeleton>;
 /**
  * Default usage example of the VoteDataListItem.Skeleton component.
  */
-export const Default: Story = {
-    render: () => (
-        <DataList.Root entityLabel="Vote" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={VoteDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.test.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { VoteDataListItem, type IVoteDataListItemSkeletonProps } from '../..';
-import { DataList } from '../../../../../core';
 
 describe('<VoteDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IVoteDataListItemSkeletonProps>) => {
         const completeProps: IVoteDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="Vote">
-                <VoteDataListItem.Skeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <VoteDataListItem.Skeleton {...completeProps} />;
     };
     it('has correct accessibility attributes', () => {
         render(createTestComponent());

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemSkeleton/voteDataListItemSkeleton.tsx
@@ -1,6 +1,6 @@
 import { DataList, StateSkeletonBar, StateSkeletonCircular, type IDataListItemProps } from '../../../../../core';
 
-export interface IVoteDataListItemSkeletonProps extends IDataListItemProps {}
+export type IVoteDataListItemSkeletonProps = IDataListItemProps;
 
 export const VoteDataListItemSkeleton: React.FC<IVoteDataListItemSkeletonProps> = (props) => {
     const { ...otherProps } = props;

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.stories.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { VoteDataListItem } from '..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof VoteDataListItem.Structure> = {
     title: 'Modules/Components/Vote/VoteDataListItem/VoteDataListItem.Structure',
@@ -25,13 +24,6 @@ export const TokenVoting: Story = {
         votingPower: 1230000,
         tokenSymbol: 'PDC',
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Votes">
-            <DataList.Container>
-                <VoteDataListItem.Structure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -42,13 +34,6 @@ export const Multisig: Story = {
         voter: { address: '0x1234567890123456789012345678901234567890', name: 'vitalik.eth' },
         voteIndicator: 'approve',
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Votes">
-            <DataList.Container>
-                <VoteDataListItem.Structure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -64,13 +49,6 @@ export const TokenVotingLongNames: Story = {
         votingPower: 123456789,
         tokenSymbol: 'PDC',
     },
-    render: (args) => (
-        <DataList.Root entityLabel="Votes">
-            <DataList.Container>
-                <VoteDataListItem.Structure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.test.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import * as viem from 'viem';
 import * as wagmi from 'wagmi';
-import { DataList, NumberFormat, formatterUtils } from '../../../../../core';
+import { NumberFormat, formatterUtils } from '../../../../../core';
 import { addressUtils } from '../../../../utils';
 import { VoteDataListItemStructure, type IVoteDataListItemStructureProps } from '../../voteDataListItem';
 
@@ -10,9 +10,7 @@ jest.mock('../../../../../core/components/tag', () => ({
     Tag: ({ label }: { label: string }) => <div data-testid="tag">{label}</div>,
 }));
 
-jest.mock('../../../member', () => ({
-    MemberAvatar: () => <div data-testid="member-avatar" />,
-}));
+jest.mock('../../../member', () => ({ MemberAvatar: () => <div data-testid="member-avatar" /> }));
 
 describe('<VoteDataListItemStructure /> component', () => {
     const isAddressSpy = jest.spyOn(viem, 'isAddress');
@@ -26,13 +24,7 @@ describe('<VoteDataListItemStructure /> component', () => {
             ...props,
         };
 
-        return (
-            <DataList.Root entityLabel="Votes">
-                <DataList.Container>
-                    <VoteDataListItemStructure {...completeProps} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+        return <VoteDataListItemStructure {...completeProps} />;
     };
 
     beforeEach(() => {
@@ -45,7 +37,9 @@ describe('<VoteDataListItemStructure /> component', () => {
     });
 
     afterEach(() => {
-        jest.clearAllMocks();
+        isAddressSpy.mockReset();
+        getAddressSpy.mockReset();
+        useAccountSpy.mockReset();
     });
 
     it('renders the vote and the voter information', () => {

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.tsx
@@ -7,7 +7,7 @@ import { MemberAvatar } from '../../../member';
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { voteIndicatorToTagVariant, type VoteIndicator } from '../../voteUtils';
 
-export interface IVoteDataListItemStructureProps extends IDataListItemProps {
+export type IVoteDataListItemStructureProps = IDataListItemProps & {
     /**
      * The account details of the voter.
      */
@@ -28,7 +28,7 @@ export interface IVoteDataListItemStructureProps extends IDataListItemProps {
      * If token-based voting, the symbol of the voting power used.
      */
     tokenSymbol?: string;
-}
+};
 
 export const VoteDataListItemStructure: React.FC<IVoteDataListItemStructureProps> = (props) => {
     const { voter, isDelegate, votingPower, tokenSymbol, voteIndicator, className, ...otherProps } = props;
@@ -41,18 +41,15 @@ export const VoteDataListItemStructure: React.FC<IVoteDataListItemStructureProps
     const resolvedUserHandle =
         voter.name != null && voter.name !== '' ? voter.name : addressUtils.truncateAddress(voter.address);
 
-    const formattedTokenNumber = formatterUtils.formatNumber(votingPower, {
-        format: NumberFormat.TOKEN_AMOUNT_SHORT,
-    });
+    const formattedTokenNumber = formatterUtils.formatNumber(votingPower, { format: NumberFormat.TOKEN_AMOUNT_SHORT });
     const formattedTokenVote = `${formattedTokenNumber} ${tokenSymbol}`;
 
     const isTokenVoting = votingPower != null && tokenSymbol != null;
     const centerInfoClassNames = classNames(
         'flex w-full min-w-0 shrink flex-col gap-y-1 text-base font-normal leading-tight md:gap-y-1.5 md:text-lg',
-        {
-            'py-3 md:py-3.5': !isTokenVoting,
-        },
+        { 'py-3 md:py-3.5': !isTokenVoting },
     );
+
     return (
         <DataList.Item className={classNames('flex items-center gap-x-3 md:gap-x-4', className)} {...otherProps}>
             <MemberAvatar

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.stories.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { VoteProposalDataListItem } from '..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof VoteProposalDataListItem.Skeleton> = {
     title: 'Modules/Components/Vote/VoteProposalDataListItem/VoteProposalDataListItem.Skeleton',
@@ -18,12 +17,6 @@ type Story = StoryObj<typeof VoteProposalDataListItem.Skeleton>;
 /**
  * Default usage example of the VoteProposalDataListItem.Skeleton component.
  */
-export const Default: Story = {
-    render: () => (
-        <DataList.Root entityLabel="Vote" state="initialLoading" pageSize={1}>
-            <DataList.Container SkeletonElement={VoteProposalDataListItem.Skeleton} />
-        </DataList.Root>
-    ),
-};
+export const Default: Story = {};
 
 export default meta;

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.test.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { VoteProposalDataListItem, type IVoteProposalDataListItemSkeletonProps } from '../..';
-import { DataList } from '../../../../../core';
 
 describe('<VoteProposalDataListItem.Skeleton /> component', () => {
     const createTestComponent = (props?: Partial<IVoteProposalDataListItemSkeletonProps>) => {
         const completeProps: IVoteProposalDataListItemSkeletonProps = { ...props };
 
-        return (
-            <DataList.Root entityLabel="proposalVote">
-                <VoteProposalDataListItem.Skeleton {...completeProps} />
-            </DataList.Root>
-        );
+        return <VoteProposalDataListItem.Skeleton {...completeProps} />;
     };
     it('has correct accessibility attributes', () => {
         render(createTestComponent());

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemSkeleton/voteProposalDataListItemSkeleton.tsx
@@ -1,6 +1,6 @@
 import { DataList, StateSkeletonBar, type IDataListItemProps } from '../../../../../core';
 
-export interface IVoteProposalDataListItemSkeletonProps extends IDataListItemProps {}
+export type IVoteProposalDataListItemSkeletonProps = IDataListItemProps;
 
 export const VoteProposalDataListItemSkeleton: React.FC<IVoteProposalDataListItemSkeletonProps> = (props) => {
     const { ...otherProps } = props;

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.stories.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { VoteProposalDataListItem } from '..';
-import { DataList } from '../../../../../core';
 
 const meta: Meta<typeof VoteProposalDataListItem.Structure> = {
     title: 'Modules/Components/Vote/VoteProposalDataListItem/VoteProposalDataListItem.Structure',
@@ -25,13 +24,6 @@ export const TokenVoting: Story = {
         voteIndicator: 'yes',
         date: 1613984914000,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="proposalVote">
-            <DataList.Container>
-                <VoteProposalDataListItem.Structure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 /**
@@ -44,13 +36,6 @@ export const Multisig: Story = {
         voteIndicator: 'approve',
         date: 1613984914000,
     },
-    render: (args) => (
-        <DataList.Root entityLabel="proposalVote">
-            <DataList.Container>
-                <VoteProposalDataListItem.Structure {...args} />
-            </DataList.Container>
-        </DataList.Root>
-    ),
 };
 
 export default meta;

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.test.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.test.tsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { DateTime } from 'luxon';
-import { DataList } from '../../../../../core';
 import {
     VoteProposalDataListItemStructure,
     type IVoteProposalDataListItemStructureProps,
@@ -20,13 +19,7 @@ describe('<VoteProposalDataListItemStructure /> component', () => {
             ...props,
         };
 
-        return (
-            <DataList.Root entityLabel="proposalVote">
-                <DataList.Container>
-                    <VoteProposalDataListItemStructure {...completeProps} />
-                </DataList.Container>
-            </DataList.Root>
-        );
+        return <VoteProposalDataListItemStructure {...completeProps} />;
     };
 
     it('renders the vote and the proposal information', () => {

--- a/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.tsx
+++ b/src/modules/components/vote/voteProposalDataListItem/voteProposalDataListItemStructure/voteProposalDataListItemStructure.tsx
@@ -3,7 +3,7 @@ import { DataList, DateFormat, Tag, formatterUtils, type IDataListItemProps } fr
 import { useOdsModulesContext } from '../../../odsModulesProvider';
 import { voteIndicatorToTagVariant, type VoteIndicator } from '../../voteUtils';
 
-export interface IVoteProposalDataListItemStructureProps extends IDataListItemProps {
+export type IVoteProposalDataListItemStructureProps = IDataListItemProps & {
     /**
      * The ID of proposal.
      */
@@ -20,7 +20,7 @@ export interface IVoteProposalDataListItemStructureProps extends IDataListItemPr
      *  Date of the vote on the proposal in ISO format or as a timestamp
      */
     date?: number | string;
-}
+};
 
 export const VoteProposalDataListItemStructure: React.FC<IVoteProposalDataListItemStructureProps> = (props) => {
     const { proposalTitle, proposalId, voteIndicator, date, className, ...otherProps } = props;


### PR DESCRIPTION
## Description

- Support `dropdownItems` property on ProposalActions to display custom actions
- Update `DataListItem` component to support button/link rendering and standalone usage
- Update `DropdownItem` style to correctly render items with icons aligned on the left

🟥 The only breaking change of this PR would be that if some app component is extending a data-list-item property interface (`IDataListItemProps`, `IVoteDataListItemProps`, ..), the related props need to be changed from `interface` to `type`

Task: [APP-3614](https://aragonassociation.atlassian.net/browse/APP-3614)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

[APP-3614]: https://aragonassociation.atlassian.net/browse/APP-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ