### PR TITLE
feat(APP-3676): Update ProposalDataListItem component to make proposal type optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
--   Update core components `RadioCard` and `CheckboxCard` to have optional description property and correct alignment
-    when no description provided
+-   Update `RadioCard` and `CheckboxCard` core components to have optional description property, fix alignment when no
+    description provided
+-   Update `<ProposalDataListItem.Structure >` module component to make proposal type property optional and support
+    custom proposal results
 -   Bump `actions/checkout` from 4.2.0 to 4.2.1
 -   Update minor and patch NPM dependencies
 
@@ -25,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Update `Tabs` core component to handle disabled tab trigger state
 -   Support `forceMount` property on `Accordion` core component and `ProposalVotingStage` module component to correctly
-    render dynamic content on proposal stages.
+    render dynamic content on proposal stages
 
 ### Fixed
 

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
@@ -10,7 +10,7 @@ export type ProposalResult<TType extends ProposalType> = TType extends 'majority
       ? IApprovalThresholdResult
       : undefined;
 
-export type IProposalDataListItemStructureBaseProps<TType extends ProposalType = undefined> = IDataListItemProps &
+export type IProposalDataListItemStructureBaseProps<TType extends ProposalType = ProposalType> = IDataListItemProps &
     IWeb3ComponentProps & {
         /**
          * Proposal id

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.api.ts
@@ -1,10 +1,16 @@
-import { type IDataListItemProps } from '../../../../../core';
+import type { IDataListItemProps } from '../../../../../core';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../../types';
 import { type ProposalStatus } from '../../proposalUtils';
 
-export type ProposalType = 'majorityVoting' | 'approvalThreshold';
+export type ProposalType = 'majorityVoting' | 'approvalThreshold' | undefined;
 
-export type IProposalDataListItemStructureBaseProps<TType extends ProposalType = ProposalType> = IDataListItemProps &
+export type ProposalResult<TType extends ProposalType> = TType extends 'majorityVoting'
+    ? IMajorityVotingResult
+    : TType extends 'approvalThreshold'
+      ? IApprovalThresholdResult
+      : undefined;
+
+export type IProposalDataListItemStructureBaseProps<TType extends ProposalType = undefined> = IDataListItemProps &
     IWeb3ComponentProps & {
         /**
          * Proposal id
@@ -25,7 +31,7 @@ export type IProposalDataListItemStructureBaseProps<TType extends ProposalType =
         /**
          * Result of the proposal shown only when it is active, challenged or vetoed.
          */
-        result?: TType extends 'majorityVoting' ? IMajorityVotingResult : IApprovalThresholdResult;
+        result?: ProposalResult<TType>;
         /**
          * Proposal status
          */
@@ -41,7 +47,7 @@ export type IProposalDataListItemStructureBaseProps<TType extends ProposalType =
         /**
          * Type of the ProposalDataListItem
          */
-        type: TType;
+        type?: TType;
         /**
          * Indicates whether the connected wallet has voted
          */
@@ -100,5 +106,6 @@ export interface IMajorityVotingResult extends IProposalResultBase {
 }
 
 export type IProposalDataListItemStructureProps =
+    | IProposalDataListItemStructureBaseProps<undefined>
     | IProposalDataListItemStructureBaseProps<'majorityVoting'>
     | IProposalDataListItemStructureBaseProps<'approvalThreshold'>;

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ProposalDataListItem, ProposalStatus } from '../../index';
-import { type IProposalDataListItemStructureProps } from './proposalDataListItemStructure.api';
 
 const meta: Meta<typeof ProposalDataListItem.Structure> = {
     title: 'Modules/Components/Proposal/ProposalDataListItem/ProposalDataListItem.Structure',
@@ -15,21 +14,18 @@ const meta: Meta<typeof ProposalDataListItem.Structure> = {
 
 type Story = StoryObj<typeof ProposalDataListItem.Structure>;
 
-const basePublisher = {
-    address: '0xd5fb864ACfD6BB2f72939f122e89fF7F475924f5',
-    link: 'https://app.aragon.org/#/daos/base/0xd2705c56aa4edb98271cb8cea2b0df3288ad4585/members/0xd5fb864ACfD6BB2f72939f122e89fF7F475924f5',
-};
-
-const baseArgs: Omit<IProposalDataListItemStructureProps, 'result' | 'publisher'> = {
-    date: 1719963030308,
-    status: ProposalStatus.ACTIVE,
-    title: 'This is a very serious proposal to send funds to a wallet address',
-    summary: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vel eleifend neque, in mattis eros.
-        Integer ornare dapibus sem sit amet viverra. Sed blandit ipsum quis erat elementum lacinia.
-        Sed eu nisi urna. Ut quis urna ac mi vulputate suscipit. Aenean lacinia, libero sit amet laoreet vulputate,
-        magna magna sollicitudin tellus, ut volutpat nulla arcu nec neque. Phasellus vulputate tincidunt orci vitae eleifend.`,
-    type: 'majorityVoting',
-    voted: false,
+/**
+ * Default usage example of the `ProposalDataListItem.Structure` module component.
+ */
+export const Default: Story = {
+    args: {
+        date: 1728637284503,
+        status: ProposalStatus.ACCEPTED,
+        title: 'Funding testnet of Unichain',
+        summary:
+            'This covers the fees associated with the final development on the Unichain Testnet and development of the bridge for the mainnet.',
+        publisher: { address: '0x17C6808fA04DC9de98eaCfeb4c66B352067c1cDD' },
+    },
 };
 
 /**
@@ -37,14 +33,14 @@ const baseArgs: Omit<IProposalDataListItemStructureProps, 'result' | 'publisher'
  */
 export const MajorityVoting: Story = {
     args: {
-        ...baseArgs,
-        publisher: { ...basePublisher },
+        date: 1691664284000,
+        status: ProposalStatus.ACTIVE,
+        title: 'Update DAO metadata',
+        summary: 'Update the name, logo and description of the DAO.',
+        voted: true,
+        publisher: { address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', name: 'vitalik.eth' },
         type: 'majorityVoting',
-        result: {
-            option: 'yes',
-            voteAmount: '100k wAnt',
-            votePercentage: 15,
-        },
+        result: { option: 'yes', voteAmount: '100k wAnt', votePercentage: 15 },
     },
 };
 
@@ -53,13 +49,14 @@ export const MajorityVoting: Story = {
  */
 export const ApprovalThreshold: Story = {
     args: {
-        ...baseArgs,
-        publisher: { ...basePublisher, name: 'sio.eth' },
+        date: 1638723612000,
+        status: ProposalStatus.ACTIVE,
+        title: 'Add new DAO member',
+        summary: `Adding a new member to the DAO. This is a long description to test if the component correctly truncated
+            the proposal description. This is a long description to test if the component correctly truncated the proposal description.`,
+        publisher: { address: '0xd5fb864ACfD6BB2f72939f122e89fF7F475924f5', name: 'sio.eth' },
         type: 'approvalThreshold',
-        result: {
-            approvalAmount: 4,
-            approvalThreshold: 6,
-        },
+        result: { approvalAmount: 4, approvalThreshold: 6 },
     },
 };
 
@@ -68,20 +65,20 @@ export const ApprovalThreshold: Story = {
  */
 export const MultiBody: Story = {
     args: {
-        ...baseArgs,
+        date: 1580338809000,
+        status: ProposalStatus.ACTIVE,
+        title: 'Partnering with WalletConnect on Social Media',
+        summary:
+            'This is round 1 of our community engagement and building gamfi strategy with our marketing team partnership.',
         id: 'PIP-1',
         publisher: [
-            { ...basePublisher, name: '0xRugg', link: undefined },
-            { ...basePublisher, name: 'Bob the Builder', link: undefined },
-            { ...basePublisher, name: 'sio.eth' },
-            { ...basePublisher },
+            { address: '0x17366cae2b9c6C3055e9e3C78936a69006BE5409', name: 'cgero.eth', link: undefined },
+            { address: '0x9d0920D3D7c9F28baF0abed7f2E26A5126cc0786', name: 'Bob the Builder', link: undefined },
+            { address: '0xd5fb864ACfD6BB2f72939f122e89fF7F475924f5', name: 'sio.eth' },
+            { address: '0xbC7f20ebB9AeDe6DF4965eCAAcfBb24927Ae16E7' },
         ],
         type: 'approvalThreshold',
-        result: {
-            stage: { title: 'Founders Approval Council', id: '1' },
-            approvalAmount: 4,
-            approvalThreshold: 6,
-        },
+        result: { stage: { title: 'Founders Approval Council', id: '1' }, approvalAmount: 4, approvalThreshold: 6 },
     },
 };
 

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.stories.tsx
@@ -82,4 +82,22 @@ export const MultiBody: Story = {
     },
 };
 
+/**
+ * Usage example of the `ProposalDataListItem.Structure` with custom proposal results UI.
+ */
+export const CustomResults: Story = {
+    args: {
+        date: 1728637491379,
+        status: ProposalStatus.FAILED,
+        title: 'A proposal with custom results',
+        summary: 'Pass the custom proposal results as children property to render a custom UI.',
+        publisher: { address: '0x17C6808fA04DC9de98eaCfeb4c66B352067c1cDD' },
+        children: (
+            <div className="flex h-24 w-full items-center justify-center border border-dashed border-info-300 bg-info-100">
+                Custom results breakdown
+            </div>
+        ),
+    },
+};
+
 export default meta;

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.test.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.test.tsx
@@ -5,11 +5,7 @@ import { modulesCopy } from '../../../../assets';
 import { addressUtils } from '../../../../utils/addressUtils';
 import { ProposalStatus } from '../../proposalUtils';
 import { ProposalDataListItemStructure, maxPublishersDisplayed } from './proposalDataListItemStructure';
-import {
-    type IApprovalThresholdResult,
-    type IMajorityVotingResult,
-    type IProposalDataListItemStructureProps,
-} from './proposalDataListItemStructure.api';
+import { type IProposalDataListItemStructureProps } from './proposalDataListItemStructure.api';
 
 jest.mock('wagmi', () => ({ ...jest.requireActual('wagmi'), useAccount: jest.fn() }));
 
@@ -30,34 +26,23 @@ describe('<ProposalDataListItemStructure/> component', () => {
     });
 
     const createTestComponent = (props?: Partial<IProposalDataListItemStructureProps>) => {
-        const baseProps: Omit<IProposalDataListItemStructureProps, 'result'> = {
+        const defaultProps = {
             publisher: { address: '0x0000000000000000000000000000000000000000', link: '#' },
             status: ProposalStatus.ACTIVE,
             summary: 'Example Summary',
             title: 'Example Title',
             type: 'approvalThreshold',
             ...props,
-        };
+        } as IProposalDataListItemStructureProps;
 
-        const approvalResult: IApprovalThresholdResult = {
-            approvalAmount: 1,
-            approvalThreshold: 2,
-            ...props?.result,
-        };
-
-        const majorityVotingProps: IMajorityVotingResult = {
-            option: 'yes',
-            voteAmount: '100 wAnt',
-            votePercentage: 10,
-            ...props?.result,
-        };
-
-        if (baseProps.type === 'approvalThreshold') {
-            return <ProposalDataListItemStructure {...baseProps} result={approvalResult} type="approvalThreshold" />;
-        }
-
-        return <ProposalDataListItemStructure {...baseProps} result={majorityVotingProps} type="majorityVoting" />;
+        return <ProposalDataListItemStructure {...defaultProps} />;
     };
+
+    it('renders the children property to support custom proposal results', () => {
+        const children = 'custom-results';
+        render(createTestComponent({ children }));
+        expect(screen.getByText(children)).toBeInTheDocument();
+    });
 
     it("renders 'You' as the publisher if the connected address is the publisher address", () => {
         const publisher = { address: '0x0000000000000000000000000000000000000000', link: '#' };

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
@@ -20,9 +20,6 @@ const parsePublisher = (publisher: IPublisher, isConnected: boolean, connectedAd
     return { label: publisherLabel, link: publisher.link };
 };
 
-/**
- * `ProposalDataListItemStructure` module component
- */
 export const ProposalDataListItemStructure: React.FC<IProposalDataListItemStructureProps> = (props) => {
     const {
         wagmiConfig: config,
@@ -38,6 +35,7 @@ export const ProposalDataListItemStructure: React.FC<IProposalDataListItemStruct
         summary,
         title,
         voted,
+        children,
         ...otherProps
     } = props;
 
@@ -66,6 +64,8 @@ export const ProposalDataListItemStructure: React.FC<IProposalDataListItemStruct
             {isOngoing && type === 'approvalThreshold' && result && <ApprovalThresholdResult {...result} />}
 
             {isOngoing && type === 'majorityVoting' && result && <MajorityVotingResult {...result} />}
+
+            {children}
 
             <div className="flex items-center justify-between gap-x-4 md:gap-x-6">
                 <div


### PR DESCRIPTION
## Description

- Set proposal type optional on ProposalDataListItem component to make it more flexible and support custom governance plugins.

Task: [APP-3676](https://aragonassociation.atlassian.net/browse/APP-3676)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3676]: https://aragonassociation.atlassian.net/browse/APP-3676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ