### PR TITLE
Fix markdown paste in RichText

### DIFF
--- a/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
@@ -67,6 +67,14 @@ describe('<TextAreaRichText /> component', () => {
         expect(onChange).toHaveBeenLastCalledWith('');
     });
 
+    it('formats pasted markdown content', async () => {
+        const onChange = jest.fn();
+        render(createTestComponent({ onChange }));
+        const markdown = '# Heading';
+        await userEvent.paste(screen.getByRole('textbox'), markdown);
+        expect(onChange).toHaveBeenLastCalledWith('<h1>Heading</h1>');
+    });
+
     it('renders the textarea as a React portal on expand action click', async () => {
         const user = userEvent.setup();
         render(createTestComponent());

--- a/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tiptap/extension-link';
 import { Placeholder } from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import { StarterKit } from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -52,6 +53,7 @@ export const TextAreaRichText: React.FC<ITextAreaRichTextProps> = (props) => {
         StarterKit,
         Placeholder.configure({ placeholder, emptyNodeClass: placeholderClasses, showOnlyWhenEditable: false }),
         Link,
+        Markdown,
     ];
 
     const editor = useEditor({


### PR DESCRIPTION
## Summary
- support Markdown in `TextAreaRichText`
- test that pasted markdown headings render correctly

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*
- `yarn lint` *(fails: Couldn't find the node_modules state file)*


------
https://chatgpt.com/codex/tasks/task_e_683a14822cb4832e88f85d69030a5ca7