### PR TITLE
fix: Add quadrillion to number formatter

### DIFF
--- a/.changeset/big-numbers-lie.md
+++ b/.changeset/big-numbers-lie.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': minor
+---
+
+Add quadrillion number formatting to number formatter utility

--- a/src/core/utils/formatterUtils/formatterUtils.mdx
+++ b/src/core/utils/formatterUtils/formatterUtils.mdx
@@ -61,7 +61,7 @@ Generic quantities represent anything countable, such as members, proposals, vot
 **Examples**:
 
 <FormatExampleTable
-    values={[-1234, 0, 123, 1234, 1234567, 1234567890, 1234567890123, 1234567890123456]}
+    values={[-1234, 0, 123, 1234, 1234567, 1234567890, 1234567890123, 1234567890123456, 1234567890123456789, ]}
     formats={[NumberFormat.GENERIC_SHORT, NumberFormat.GENERIC_LONG]}
 />
 
@@ -74,7 +74,7 @@ Fiat totals represent any summed monetary value, such as treasury amounts or fia
 <FormatExampleTable
     values={[
         -1234.56789, -0.012345678, -0.0012345678, -0.0000001234, 0, 0.0000001234, 0.0012345678, 0.012345678, 0.12345678,
-        123.45678, 1234.56789, 1234567.89012, 1234567890.12345, 1234567890123.45678, 1234567890123456.78901,
+        123.45678, 1234.56789, 1234567.89012, 1234567890.12345, 1234567890123.45678, 1234567890123456.78901, 1234567890123456789.01234,
     ]}
     formats={[NumberFormat.FIAT_TOTAL_SHORT, NumberFormat.FIAT_TOTAL_LONG]}
 />
@@ -89,7 +89,7 @@ Token amounts represent whole or fractional amounts of tokens, such as withdrawa
     values={[
         -1234.5678, -0.0123456789012345678, -0.0012, -0.0000001234, 0, 0.0000001234, 0.0012, 0.0123456789012345678,
         0.12345678901234567, 123.4567, 1234, 1234.5678, 1234567.8901, 1234567890.1234, 1234567890123.4567,
-        1234567890123456.789,
+        1234567890123456.789, 1234567890123456789.012,
     ]}
     formats={[NumberFormat.TOKEN_AMOUNT_SHORT, NumberFormat.TOKEN_AMOUNT_LONG]}
 />

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -167,54 +167,6 @@ describe('formatter utils', () => {
 
         describe('token prices', () => {
             test.each([
-                { value: -1234.5678, result: '-1,234.5678' },
-                { value: -1234.5678, result: '-1.234,5678', locale: 'de' },
-                { value: -0.012_345_678_901_234_567_8, result: '-0.012345678901234568' },
-                { value: 0, result: '0' },
-                { value: 0.0012, result: '0.0012' },
-                { value: 0.0012, result: '+0.0012', withSign: true },
-                { value: 0.012_345_678_901_234_567_8, result: '0.012345678901234568' },
-                { value: 0.123_456_789_012_345_67, result: '0.12345678901234566' },
-                { value: 123.4567, result: '123.4567' },
-                { value: 1234, result: '1,234' },
-                { value: 1234, result: '+1,234', withSign: true },
-                { value: 1234.5678, result: '1,234.5678' },
-                { value: 1_234_567.8901, result: '1,234,567.8901' },
-                { value: 1_234_567_890.1234, result: '1,234,567,890.1234' },
-                { value: 1_234_567_890_123.4567, result: '1,234,567,890,123.4568' },
-                { value: 1_234_567_890_123_456.789, result: '1,234,567,890,123,456.8' },
-            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
-                setLocale({ number: locale });
-                expect(
-                    formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_LONG, ...options }),
-                ).toEqual(result);
-            });
-
-            test.each([
-                { value: -1234, result: '-1.23K' },
-                { value: -1234, result: '-1,23K', locale: 'de' },
-                { value: -0.005, result: '-0.01' },
-                { value: -0.0012, result: '-0.00' },
-                { value: 0, result: '0' },
-                { value: 0.0012, result: '0.00' },
-                { value: 0.005, result: '0.01' },
-                { value: 0.012_345_678_901_234_567_8, result: '0.01' },
-                { value: 0.123_456_789_012_345_67, result: '0.12' },
-                { value: 123.4567, result: '123.46' },
-                { value: 1234, result: '1.23K' },
-                { value: 1234.5678, result: '1.23K' },
-                { value: 1_234_567.8901, result: '1.23M' },
-                { value: 1_234_567_890.1234, result: '1.23B' },
-                { value: 1_234_567_890_123.4567, result: '1.23T' },
-                { value: 1_234_567_890_123_456.789, result: '1.23P' },
-            ])('formats $value as $result using short format', ({ value, result, locale }) => {
-                setLocale({ number: locale });
-                expect(formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_SHORT })).toEqual(result);
-            });
-        });
-
-        describe('token prices', () => {
-            test.each([
                 { value: -1234.567_89, result: '-$1,234.57' },
                 { value: -1234.567_89, result: '-1.234,57 $', locale: 'de' },
                 { value: -0.001_234_567_8, result: '-$0.001235' },

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -206,7 +206,7 @@ describe('formatter utils', () => {
                 { value: 1_234_567.8901, result: '1.23M' },
                 { value: 1_234_567_890.1234, result: '1.23B' },
                 { value: 1_234_567_890_123.4567, result: '1.23T' },
-                { value: 1_234_567_890_123_456.789, result: '1.23 x 10^15' },
+                { value: 1_234_567_890_123_456.789, result: '1.23P' },
             ])('formats $value as $result using short format', ({ value, result, locale }) => {
                 setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_SHORT })).toEqual(result);

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -60,7 +60,7 @@ describe('formatter utils', () => {
                 { value: 1_234_567, result: '1.23M' },
                 { value: 1_234_567_890, result: '1.23B' },
                 { value: 1_234_567_890_123, result: '1.23T' },
-                { value: 1_234_567_890_123_456, result: '1.23 x 10^15' },
+                { value: 1_234_567_890_123_456, result: '1.23P' },
             ])('formats $value as $result using short format', ({ value, result, locale, ...options }) => {
                 setLocale({ number: locale });
                 expect(formatterUtils.formatNumber(value, { format: NumberFormat.GENERIC_SHORT, ...options })).toEqual(
@@ -72,7 +72,7 @@ describe('formatter utils', () => {
         describe('fiat total amounts', () => {
             test.each([
                 { value: -1234.567_89, result: '-$1,234.57' },
-                { value: -1234.567_89, result: '-1.234,57 $', locale: 'de' },
+                { value: -1234.567_89, result: '-1.234,57 $', locale: 'de' },
                 { value: -0.012_345_678, result: '-$0.01' },
                 { value: -0.001_234_567_8, result: '-$0.00' },
                 { value: 0, result: '$0.00' },
@@ -109,7 +109,7 @@ describe('formatter utils', () => {
                 { value: 1_234_567.890_12, result: '$1.23M' },
                 { value: 1_234_567_890.123_45, result: '$1.23B' },
                 { value: 1_234_567_890_123.456_78, result: '$1.23T' },
-                { value: 1_234_567_890_123_456.789_01, result: '$1.23 x 10^15' },
+                { value: 1_234_567_890_123_456.789_01, result: '$1.23P' },
             ])('formats $value as $result using short format', ({ value, result, ...options }) => {
                 expect(
                     formatterUtils.formatNumber(value, { format: NumberFormat.FIAT_TOTAL_SHORT, ...options }),
@@ -118,6 +118,54 @@ describe('formatter utils', () => {
         });
 
         describe('token amounts', () => {
+            test.each([
+                { value: -1234.5678, result: '-1,234.5678' },
+                { value: -1234.5678, result: '-1.234,5678', locale: 'de' },
+                { value: -0.012_345_678_901_234_567_8, result: '-0.012345678901234568' },
+                { value: 0, result: '0' },
+                { value: 0.0012, result: '0.0012' },
+                { value: 0.0012, result: '+0.0012', withSign: true },
+                { value: 0.012_345_678_901_234_567_8, result: '0.012345678901234568' },
+                { value: 0.123_456_789_012_345_67, result: '0.12345678901234566' },
+                { value: 123.4567, result: '123.4567' },
+                { value: 1234, result: '1,234' },
+                { value: 1234, result: '+1,234', withSign: true },
+                { value: 1234.5678, result: '1,234.5678' },
+                { value: 1_234_567.8901, result: '1,234,567.8901' },
+                { value: 1_234_567_890.1234, result: '1,234,567,890.1234' },
+                { value: 1_234_567_890_123.4567, result: '1,234,567,890,123.4568' },
+                { value: 1_234_567_890_123_456.789, result: '1,234,567,890,123,456.8' },
+            ])('formats $value as $result using long format', ({ value, result, locale, ...options }) => {
+                setLocale({ number: locale });
+                expect(
+                    formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_LONG, ...options }),
+                ).toEqual(result);
+            });
+
+            test.each([
+                { value: -1234, result: '-1.23K' },
+                { value: -1234, result: '-1,23K', locale: 'de' },
+                { value: -0.005, result: '-0.01' },
+                { value: -0.0012, result: '-0.00' },
+                { value: 0, result: '0' },
+                { value: 0.0012, result: '0.00' },
+                { value: 0.005, result: '0.01' },
+                { value: 0.012_345_678_901_234_567_8, result: '0.01' },
+                { value: 0.123_456_789_012_345_67, result: '0.12' },
+                { value: 123.4567, result: '123.46' },
+                { value: 1234, result: '1.23K' },
+                { value: 1234.5678, result: '1.23K' },
+                { value: 1_234_567.8901, result: '1.23M' },
+                { value: 1_234_567_890.1234, result: '1.23B' },
+                { value: 1_234_567_890_123.4567, result: '1.23T' },
+                { value: 1_234_567_890_123_456.789, result: '1.23P' },
+            ])('formats $value as $result using short format', ({ value, result, locale }) => {
+                setLocale({ number: locale });
+                expect(formatterUtils.formatNumber(value, { format: NumberFormat.TOKEN_AMOUNT_SHORT })).toEqual(result);
+            });
+        });
+
+        describe('token prices', () => {
             test.each([
                 { value: -1234.5678, result: '-1,234.5678' },
                 { value: -1234.5678, result: '-1.234,5678', locale: 'de' },

--- a/src/core/utils/formatterUtils/formatterUtils.test.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.test.ts
@@ -72,7 +72,7 @@ describe('formatter utils', () => {
         describe('fiat total amounts', () => {
             test.each([
                 { value: -1234.567_89, result: '-$1,234.57' },
-                { value: -1234.567_89, result: '-1.234,57 $', locale: 'de' },
+                { value: -1234.567_89, result: '-1.234,57 $', locale: 'de' },
                 { value: -0.012_345_678, result: '-$0.01' },
                 { value: -0.001_234_567_8, result: '-$0.00' },
                 { value: 0, result: '$0.00' },

--- a/src/core/utils/formatterUtils/formatterUtils.ts
+++ b/src/core/utils/formatterUtils/formatterUtils.ts
@@ -32,7 +32,8 @@ class FormatterUtils {
     currencyLocale = 'USD';
 
     private baseSymbolRanges = [
-        { value: 1e15, symbol: (value: number) => ` x 10^${(this.getDecimalPlaces(value) - 1).toString()}` },
+        { value: 1e18, symbol: (value: number) => ` x 10^${(this.getDecimalPlaces(value) - 1).toString()}` },
+        { value: 1e15, symbol: () => 'P' },
         { value: 1e12, symbol: () => 'T' },
         { value: 1e9, symbol: () => 'B' },
         { value: 1e6, symbol: () => 'M' },
@@ -86,7 +87,7 @@ class FormatterUtils {
 
         const baseRange = this.baseSymbolRanges.find((range) => Math.abs(processedValue) >= range.value);
         const baseRangeDenominator =
-            processedValue > 1e15 ? 10 ** (this.getDecimalPlaces(processedValue) - 1) : (baseRange?.value ?? 1);
+            processedValue > 1e18 ? 10 ** (this.getDecimalPlaces(processedValue) - 1) : (baseRange?.value ?? 1);
 
         if (useBaseSymbol) {
             processedValue /= baseRangeDenominator;

--- a/src/core/utils/formatterUtils/formatterUtilsDefinitions.ts
+++ b/src/core/utils/formatterUtils/formatterUtilsDefinitions.ts
@@ -23,7 +23,7 @@ export interface INumberFormat {
      */
     minFractionDigits?: number;
     /**
-     * Uses the base symbol (K, M, B, T) when set to true.
+     * Uses the base symbol (K, M, B, T, P) when set to true.
      */
     useBaseSymbol?: boolean;
     /**


### PR DESCRIPTION
## Description

Chiliz has a token with a quadrillion supply. They requested we support this without going into scientific notation so soon.

## Type of change

<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
