### PR TITLE
feat: Add Clipboard component to address in member list item

### DIFF
--- a/.changeset/pretty-months-clean.md
+++ b/.changeset/pretty-months-clean.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": minor
+---
+
+Add Clipboard component to address in member list item

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const config = {
     coveragePathIgnorePatterns: ['.d.ts', '.api.ts', 'index.ts', '.stories.tsx', './src/core/test/*'],
     setupFilesAfterEnv: ['<rootDir>/src/core/test/setup.ts'],
     globalSetup: '<rootDir>/src/core/test/globalSetup.ts',
+    maxWorkers: '70%',
     transform: {
         '^.+\\.svg$': '<rootDir>/src/core/test/svgTransform.js',
         '^.+\\.m?[tj]sx?$': [

--- a/src/core/components/clipboard/clipboard.stories.tsx
+++ b/src/core/components/clipboard/clipboard.stories.tsx
@@ -98,4 +98,26 @@ export const InsideClickable: Story = {
     ),
 };
 
+/**
+ * Example of the Clipboard component inside an anchor element, demonstrating that clicking the
+ * copy button does not trigger the link's default navigation behavior.
+ */
+export const InsideLink: Story = {
+    args: {
+        copyValue: '0x123456789',
+        variant: 'avatar-white-bg',
+    },
+    render: (props) => (
+        <a
+            className="flex items-center gap-2 rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 hover:bg-neutral-50"
+            href="https://example.com"
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            <span className="text-neutral-500 text-sm">{props.copyValue}</span>
+            <Clipboard {...props} />
+        </a>
+    ),
+};
+
 export default meta;

--- a/src/core/components/clipboard/clipboard.stories.tsx
+++ b/src/core/components/clipboard/clipboard.stories.tsx
@@ -77,4 +77,25 @@ export const InsideForm: Story = {
     ),
 };
 
+/**
+ * Example of the Clipboard component inside a clickable parent, demonstrating that clicking the copy
+ * button does not propagate the click event to the parent element.
+ */
+export const InsideClickable: Story = {
+    args: {
+        copyValue: '0x123456789',
+        variant: 'avatar-white-bg',
+    },
+    render: (props) => (
+        <button
+            className="flex items-center gap-2 rounded-xl border border-neutral-100 bg-neutral-0 px-4 py-3 hover:bg-neutral-50"
+            onClick={() => alert('Parent clicked!')}
+            type="button"
+        >
+            <span className="text-neutral-500 text-sm">{props.copyValue}</span>
+            <Clipboard {...props} />
+        </button>
+    ),
+};
+
 export default meta;

--- a/src/core/components/clipboard/clipboard.test.tsx
+++ b/src/core/components/clipboard/clipboard.test.tsx
@@ -72,6 +72,27 @@ describe('<Clipboard /> component', () => {
         }
     });
 
+    it('does not trigger parent click handler when clicked', async () => {
+        const handleParentClick = jest.fn();
+
+        const variants: IClipboardProps['variant'][] = ['avatar', 'avatar-white-bg', 'button'];
+
+        for (const variant of variants) {
+            handleParentClick.mockReset();
+            const { unmount } = render(
+                // biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/useSemanticElements: test-only wrapper simulating a clickable parent
+                <div onClick={handleParentClick} role="button" tabIndex={0}>
+                    {createTestComponent({ variant })}
+                </div>,
+            );
+
+            await userEvent.click(screen.getAllByRole('button').at(-1)!);
+
+            expect(handleParentClick).not.toHaveBeenCalled();
+            unmount();
+        }
+    });
+
     it('optionally renders children besides the clipboard', () => {
         const childText = 'Child text';
         const icon = IconType.COPY;

--- a/src/core/components/clipboard/clipboard.test.tsx
+++ b/src/core/components/clipboard/clipboard.test.tsx
@@ -110,6 +110,40 @@ describe('<Clipboard /> component', () => {
         }
     });
 
+    it('does not trigger anchor navigation when clicked inside a link', async () => {
+        const handleAnchorClick = jest.fn();
+
+        const variants: IClipboardProps['variant'][] = [
+            'avatar',
+            'avatar-white-bg',
+            'avatar-neutral-white-bg',
+            'button',
+        ];
+
+        for (const variant of variants) {
+            handleAnchorClick.mockReset();
+            const { unmount } = render(
+                <a
+                    href="https://example.com"
+                    onClick={(e) => {
+                        handleAnchorClick(e.defaultPrevented);
+                    }}
+                >
+                    {createTestComponent({ variant })}
+                </a>,
+            );
+
+            await userEvent.click(screen.getAllByRole('button').at(-1)!);
+
+            // Either the click never bubbled to the anchor (stopPropagation), or it did but
+            // default was prevented. Both outcomes prevent navigation.
+            if (handleAnchorClick.mock.calls.length > 0) {
+                expect(handleAnchorClick).toHaveBeenCalledWith(true);
+            }
+            unmount();
+        }
+    });
+
     it('optionally renders children besides the clipboard', () => {
         const childText = 'Child text';
         const icon = IconType.COPY;

--- a/src/core/components/clipboard/clipboard.test.tsx
+++ b/src/core/components/clipboard/clipboard.test.tsx
@@ -47,6 +47,13 @@ describe('<Clipboard /> component', () => {
         expect(screen.getByTestId(icon)).toBeInTheDocument();
     });
 
+    it('renders avatar-neutral-white-bg variant', () => {
+        const icon = IconType.COPY;
+        render(createTestComponent({ variant: 'avatar-neutral-white-bg' }));
+        expect(screen.getByRole('button')).toBeInTheDocument(); // Tooltip wrapper button
+        expect(screen.getByTestId(icon)).toBeInTheDocument();
+    });
+
     it('correctly handles the copy action', async () => {
         const textToCopy = 'Text to copy';
         render(createTestComponent({ copyValue: textToCopy }));
@@ -59,7 +66,12 @@ describe('<Clipboard /> component', () => {
     it('does not trigger form submission when clicked', async () => {
         const handleSubmit = jest.fn();
 
-        const variants: IClipboardProps['variant'][] = ['avatar', 'avatar-white-bg', 'button'];
+        const variants: IClipboardProps['variant'][] = [
+            'avatar',
+            'avatar-white-bg',
+            'avatar-neutral-white-bg',
+            'button',
+        ];
 
         for (const variant of variants) {
             handleSubmit.mockReset();
@@ -75,7 +87,12 @@ describe('<Clipboard /> component', () => {
     it('does not trigger parent click handler when clicked', async () => {
         const handleParentClick = jest.fn();
 
-        const variants: IClipboardProps['variant'][] = ['avatar', 'avatar-white-bg', 'button'];
+        const variants: IClipboardProps['variant'][] = [
+            'avatar',
+            'avatar-white-bg',
+            'avatar-neutral-white-bg',
+            'button',
+        ];
 
         for (const variant of variants) {
             handleParentClick.mockReset();

--- a/src/core/components/clipboard/clipboard.tsx
+++ b/src/core/components/clipboard/clipboard.tsx
@@ -41,7 +41,10 @@ export const Clipboard: React.FC<IClipboardProps> = (props) => {
     const tooltipText = copyTexts.clipboard.copy;
 
     const icon = isCopied ? IconType.CHECKMARK : IconType.COPY;
-    const handleCopyClick = () => handleCopy(copyValue);
+    const handleCopyClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        void handleCopy(copyValue);
+    };
 
     return (
         <div className={classNames('flex items-center gap-2', className)}>

--- a/src/core/components/clipboard/clipboard.tsx
+++ b/src/core/components/clipboard/clipboard.tsx
@@ -6,7 +6,7 @@ import { useGukCoreContext } from '../gukCoreProvider';
 import { IconType } from '../icon';
 import { Tooltip } from '../tooltip';
 
-export type ClipboardVariant = 'button' | 'avatar' | 'avatar-white-bg';
+export type ClipboardVariant = 'button' | 'avatar' | 'avatar-white-bg' | 'avatar-neutral-white-bg';
 
 export interface IClipboardProps {
     /**
@@ -49,14 +49,14 @@ export const Clipboard: React.FC<IClipboardProps> = (props) => {
     return (
         <div className={classNames('flex items-center gap-2', className)}>
             {children}
-            {(variant === 'avatar' || variant === 'avatar-white-bg') && (
+            {(variant === 'avatar' || variant === 'avatar-white-bg' || variant === 'avatar-neutral-white-bg') && (
                 <Tooltip content={tooltipText} triggerAsChild={true}>
                     <button className="cursor-pointer" onClick={handleCopyClick} type="button">
                         <AvatarIcon
-                            backgroundWhite={variant === 'avatar-white-bg'}
+                            backgroundWhite={variant === 'avatar-white-bg' || variant === 'avatar-neutral-white-bg'}
                             icon={icon}
                             size={size}
-                            variant="primary"
+                            variant={variant === 'avatar-neutral-white-bg' ? 'neutral' : 'primary'}
                         />
                     </button>
                 </Tooltip>

--- a/src/core/components/clipboard/clipboard.tsx
+++ b/src/core/components/clipboard/clipboard.tsx
@@ -43,6 +43,8 @@ export const Clipboard: React.FC<IClipboardProps> = (props) => {
     const icon = isCopied ? IconType.CHECKMARK : IconType.COPY;
     const handleCopyClick = (e: React.MouseEvent) => {
         e.stopPropagation();
+        e.preventDefault(); // when inside links!
+
         void handleCopy(copyValue);
     };
 

--- a/src/core/components/clipboard/clipboard.tsx
+++ b/src/core/components/clipboard/clipboard.tsx
@@ -43,7 +43,8 @@ export const Clipboard: React.FC<IClipboardProps> = (props) => {
     const icon = isCopied ? IconType.CHECKMARK : IconType.COPY;
     const handleCopyClick = (e: React.MouseEvent) => {
         e.stopPropagation();
-        e.preventDefault(); // when inside links!
+        e.nativeEvent.stopImmediatePropagation(); // to block nextjs-toploader
+        e.preventDefault(); // when inside links
 
         void handleCopy(copyValue);
     };

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
@@ -106,7 +106,9 @@ export const MemberDataListItemStructure: React.FC<IMemberDataListItemProps> = (
                 {isCurrentUser && <Tag label={copy.memberDataListItemStructure.you} variant="neutral" />}
             </div>
             <Heading as="h2" className="inline-block w-full truncate" size="h3">
-                <Clipboard copyValue={address}>{resolvedUserHandle}</Clipboard>
+                <Clipboard copyValue={address} variant="avatar-neutral-white-bg">
+                    {resolvedUserHandle}
+                </Clipboard>
             </Heading>
             {showDelegationOrTokenInformation && (
                 <div className="flex flex-col gap-y-2">

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
@@ -1,7 +1,15 @@
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import { useConnection } from 'wagmi';
-import { DataList, formatterUtils, Heading, type IDataListItemProps, NumberFormat, Tag } from '../../../../../core';
+import {
+    Clipboard,
+    DataList,
+    formatterUtils,
+    Heading,
+    type IDataListItemProps,
+    NumberFormat,
+    Tag,
+} from '../../../../../core';
 import { addressUtils } from '../../../../utils';
 import { useGukModulesContext } from '../../../gukModulesProvider';
 import { MemberAvatar } from '../../memberAvatar';
@@ -98,7 +106,7 @@ export const MemberDataListItemStructure: React.FC<IMemberDataListItemProps> = (
                 {isCurrentUser && <Tag label={copy.memberDataListItemStructure.you} variant="neutral" />}
             </div>
             <Heading as="h2" className="inline-block w-full truncate" size="h3">
-                {resolvedUserHandle}
+                <Clipboard copyValue={address}>{resolvedUserHandle}</Clipboard>
             </Heading>
             {showDelegationOrTokenInformation && (
                 <div className="flex flex-col gap-y-2">


### PR DESCRIPTION
## Description

Wraps the resolved user handle (ENS name or formatted address) in the `MemberDataListItemStructure` component with the `Clipboard` component, allowing users to copy the underlying address directly from the member list item.

Fix of https://github.com/aragon/gov-ui-kit/pull/687

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project