### PR TITLE
feat(APP-604): Add DataList.ActionItem component

### DIFF
--- a/.changeset/crisp-wolves-draw.md
+++ b/.changeset/crisp-wolves-draw.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": minor
+---
+
+Implement DataList.ActionItem component

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.stories.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconType } from '../../icon';
+import { DataList } from '../index';
+
+const meta: Meta<typeof DataList.ActionItem> = {
+    title: 'Core/Components/DataList/DataList.ActionItem',
+    component: DataList.ActionItem,
+    parameters: {
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/P0GeJKqILL7UXvaqu5Jj7V/v1.1.0?type=design&node-id=13724-27671&mode=dev',
+        },
+    },
+};
+
+type Story = StoryObj<typeof DataList.ActionItem>;
+
+/**
+ * Primary variant — used for affirmative actions such as "Add custom address".
+ */
+export const Primary: Story = {
+    args: {
+        children: 'Add custom address',
+        icon: IconType.PLUS,
+        variant: 'primary',
+    },
+};
+
+/**
+ * Neutral variant — used for back/secondary actions such as returning to a previous step.
+ */
+export const Neutral: Story = {
+    args: {
+        children: 'Back to selection',
+        icon: IconType.CHEVRON_LEFT,
+        variant: 'neutral',
+    },
+};
+
+export default meta;

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.stories.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof DataList.ActionItem>;
  */
 export const Primary: Story = {
     args: {
-        children: 'Add custom address',
+        label: 'Add custom address',
         icon: IconType.PLUS,
         variant: 'primary',
     },
@@ -31,7 +31,7 @@ export const Primary: Story = {
  */
 export const Neutral: Story = {
     args: {
-        children: 'Back to selection',
+        label: 'Back to selection',
         icon: IconType.CHEVRON_LEFT,
         variant: 'neutral',
     },

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.test.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IconType } from '../../icon';
+import { DataListActionItem, type IDataListActionItemProps } from './dataListActionItem';
+
+describe('<DataList.ActionItem /> component', () => {
+    const createTestComponent = (props?: Partial<IDataListActionItemProps>) => {
+        const completeProps: IDataListActionItemProps = {
+            icon: IconType.PLUS,
+            variant: 'primary',
+            children: 'Action label',
+            ...props,
+        };
+
+        return <DataListActionItem {...completeProps} />;
+    };
+
+    it('renders a button with the given label and icon', () => {
+        render(createTestComponent({ children: 'Add custom address', icon: IconType.PLUS }));
+        const button = screen.getByRole('button', { name: /add custom address/i });
+        expect(button).toBeInTheDocument();
+        expect(screen.getByTestId(IconType.PLUS)).toBeInTheDocument();
+    });
+
+    it('applies primary variant classes when variant is primary', () => {
+        render(createTestComponent({ variant: 'primary' }));
+        const button = screen.getByRole('button');
+        expect(button.className).toContain('text-primary-400');
+    });
+
+    it('applies neutral variant classes when variant is neutral', () => {
+        render(createTestComponent({ variant: 'neutral' }));
+        const button = screen.getByRole('button');
+        expect(button.className).toContain('text-neutral-500');
+    });
+
+    it('calls onClick when clicked', async () => {
+        const onClick = jest.fn();
+        render(createTestComponent({ onClick }));
+        await userEvent.click(screen.getByRole('button'));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults type to button', () => {
+        render(createTestComponent());
+        expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+
+    it('respects an overriding type prop', () => {
+        render(createTestComponent({ type: 'submit' }));
+        expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
+    it('merges a custom className', () => {
+        render(createTestComponent({ className: 'custom-class' }));
+        expect(screen.getByRole('button').className).toContain('custom-class');
+    });
+});

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.test.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.test.tsx
@@ -8,7 +8,7 @@ describe('<DataList.ActionItem /> component', () => {
         const completeProps: IDataListActionItemProps = {
             icon: IconType.PLUS,
             variant: 'primary',
-            children: 'Action label',
+            label: 'Action label',
             ...props,
         };
 
@@ -16,7 +16,7 @@ describe('<DataList.ActionItem /> component', () => {
     };
 
     it('renders a button with the given label and icon', () => {
-        render(createTestComponent({ children: 'Add custom address', icon: IconType.PLUS }));
+        render(createTestComponent({ label: 'Add custom address', icon: IconType.PLUS }));
         const button = screen.getByRole('button', { name: /add custom address/i });
         expect(button).toBeInTheDocument();
         expect(screen.getByTestId(IconType.PLUS)).toBeInTheDocument();

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.tsx
@@ -1,0 +1,64 @@
+import classNames from 'classnames';
+import type { ComponentProps, ReactNode } from 'react';
+import { Icon, type IconType } from '../../icon';
+
+export type DataListActionItemVariant = 'primary' | 'neutral';
+
+export interface IDataListActionItemProps extends ComponentProps<'button'> {
+    /**
+     * Icon rendered inside the circular avatar on the left.
+     */
+    icon: IconType;
+    /**
+     * Visual variant — `primary` for affirmative actions (e.g. add),
+     * `neutral` for back/secondary actions.
+     */
+    variant: DataListActionItemVariant;
+    /**
+     * Row label rendered next to the avatar.
+     */
+    children: ReactNode;
+}
+
+const variantRowClasses: Record<DataListActionItemVariant, string> = {
+    primary: 'text-primary-400 hover:bg-primary-400/4 active:bg-primary-400/8',
+    neutral: 'text-neutral-500 hover:bg-neutral-800/4 active:bg-neutral-800/8',
+};
+
+const variantAvatarClasses: Record<DataListActionItemVariant, string> = {
+    primary: 'bg-primary-50',
+    neutral: 'bg-neutral-50',
+};
+
+const variantIconClasses: Record<DataListActionItemVariant, string> = {
+    primary: 'text-primary-400',
+    neutral: 'text-neutral-500',
+};
+
+export const DataListActionItem: React.FC<IDataListActionItemProps> = (props) => {
+    const { className, type = 'button', icon, variant, children, ...otherProps } = props;
+
+    return (
+        <button
+            className={classNames(
+                'group flex w-full items-center gap-3 rounded-xl bg-transparent px-4 py-3 text-base leading-tight transition-colors',
+                'focus-ring-primary md:gap-4 md:px-6 md:py-5 md:text-lg',
+                variantRowClasses[variant],
+                className,
+            )}
+            type={type}
+            {...otherProps}
+        >
+            <span
+                className={classNames(
+                    'flex size-6 shrink-0 items-center justify-center rounded-full transition-colors md:size-8',
+                    'group-hover:bg-neutral-0 group-focus-visible:bg-neutral-0 group-active:bg-neutral-0',
+                    variantAvatarClasses[variant],
+                )}
+            >
+                <Icon className={classNames('size-3 md:size-4', variantIconClasses[variant])} icon={icon} />
+            </span>
+            <span className="flex-1 truncate text-left">{children}</span>
+        </button>
+    );
+};

--- a/src/core/components/dataList/dataListActionItem/dataListActionItem.tsx
+++ b/src/core/components/dataList/dataListActionItem/dataListActionItem.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps } from 'react';
 import { Icon, type IconType } from '../../icon';
 
 export type DataListActionItemVariant = 'primary' | 'neutral';
@@ -17,7 +17,7 @@ export interface IDataListActionItemProps extends ComponentProps<'button'> {
     /**
      * Row label rendered next to the avatar.
      */
-    children: ReactNode;
+    label: string;
 }
 
 const variantRowClasses: Record<DataListActionItemVariant, string> = {
@@ -36,7 +36,7 @@ const variantIconClasses: Record<DataListActionItemVariant, string> = {
 };
 
 export const DataListActionItem: React.FC<IDataListActionItemProps> = (props) => {
-    const { className, type = 'button', icon, variant, children, ...otherProps } = props;
+    const { className, type = 'button', icon, variant, label, ...otherProps } = props;
 
     return (
         <button
@@ -58,7 +58,7 @@ export const DataListActionItem: React.FC<IDataListActionItemProps> = (props) =>
             >
                 <Icon className={classNames('size-3 md:size-4', variantIconClasses[variant])} icon={icon} />
             </span>
-            <span className="flex-1 truncate text-left">{children}</span>
+            <span className="flex-1 truncate text-left">{label}</span>
         </button>
     );
 };

--- a/src/core/components/dataList/dataListActionItem/index.ts
+++ b/src/core/components/dataList/dataListActionItem/index.ts
@@ -1,0 +1,5 @@
+export {
+    DataListActionItem,
+    type DataListActionItemVariant,
+    type IDataListActionItemProps,
+} from './dataListActionItem';

--- a/src/core/components/dataList/index.ts
+++ b/src/core/components/dataList/index.ts
@@ -1,3 +1,4 @@
+import { DataListActionItem } from './dataListActionItem';
 import { DataListContainer } from './dataListContainer';
 import { DataListFilter } from './dataListFilter';
 import { DataListItem } from './dataListItem';
@@ -9,9 +10,11 @@ export const DataList = {
     Filter: DataListFilter,
     Container: DataListContainer,
     Item: DataListItem,
+    ActionItem: DataListActionItem,
     Pagination: DataListPagination,
 };
 
+export * from './dataListActionItem';
 export * from './dataListContainer';
 export * from './dataListFilter';
 export * from './dataListItem';


### PR DESCRIPTION
## Description

Adds a new `DataList.ActionItem` primitive in `src/core/components/dataList/dataListActionItem/`. The component renders a full-width row with a circular icon avatar and a label, exposed as a `<button>` with two visual variants:

- `variant="primary"` — affirmative actions (e.g. "Add custom address")
- `variant="neutral"` — back/secondary actions (e.g. "Back to selection")

This extracts the shared shape of two downstream button components (`AssetAddressSelectAddButton`, `AssetAddressSelectBackButton`) so consumers can replace both with a single reusable primitive.

The component is exported both as `DataList.ActionItem` (mirroring how `DataListItem` is also `DataList.Item`) and as a named `DataListActionItem` import.

Implemented as a standalone `<button>` rather than composing `DataListItem`, because `DataListItem`'s existing variants (`primary` card / `select` transparent) do not cover the `primary` color theme this row needs, and overriding via `className` would conflict with `DataListItem`'s own hover/active classes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project