### PR TITLE
fix: Fix spacing and size issues in asset-related components

### DIFF
--- a/.changeset/silver-pillows-sell.md
+++ b/.changeset/silver-pillows-sell.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Fix spacing and size issues in Asset related components

--- a/src/core/components/dataList/dataListFilter/dataListFilter.stories.tsx
+++ b/src/core/components/dataList/dataListFilter/dataListFilter.stories.tsx
@@ -26,4 +26,16 @@ export const Default: Story = {
     ),
 };
 
+/**
+ * Example of the DataList.Filter component with loading state.
+ */
+export const Loading: Story = {
+    args: {},
+    render: (props) => (
+        <DataList.Root entityLabel="Users" state="loading">
+            <DataList.Filter {...props} />
+        </DataList.Root>
+    ),
+};
+
 export default meta;

--- a/src/core/components/dataList/dataListFilter/dataListFilter.tsx
+++ b/src/core/components/dataList/dataListFilter/dataListFilter.tsx
@@ -101,9 +101,16 @@ export const DataListFilter: React.FC<IDataListFilterProps> = (props) => {
                 )}
             >
                 {state !== 'loading' && (
-                    <AvatarIcon icon={IconType.SEARCH} size="md" variant={isFocused ? 'primary' : 'neutral'} />
+                    <AvatarIcon
+                        icon={IconType.SEARCH}
+                        responsiveSize={{ md: 'md' }}
+                        size={'sm'}
+                        variant={isFocused ? 'primary' : 'neutral'}
+                    />
                 )}
-                {state === 'loading' && <Spinner className="m-1" size="lg" variant="primary" />}
+                {state === 'loading' && (
+                    <Spinner className="m-1" responsiveSize={{ md: 'lg' }} size="md" variant="primary" />
+                )}
                 <input
                     className={classNames(
                         'search-cancel-hidden size-full truncate bg-transparent pl-3 caret-neutral-500 outline-hidden',

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -46,10 +46,10 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
 
     return (
         <DataList.Item
-            className={classNames('flex items-center justify-between gap-x-3 py-3 md:gap-x-4 md:py-5', className)}
+            className={classNames('flex items-center justify-between gap-x-3 py-3 md:py-5', className)}
             {...otherProps}
         >
-            <div className="flex min-w-0 items-center gap-3">
+            <div className="flex min-w-0 items-center gap-3 md:gap-4">
                 <Avatar className="block shrink-0" responsiveSize={{ md: 'md', sm: 'sm' }} src={logoSrc} />
                 <span className="truncate text-base text-neutral-800 leading-tight md:text-lg">{name}</span>
             </div>

--- a/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
+++ b/src/modules/components/asset/assetDataListItem/assetDataListItemStructure/assetDataListItemStructure.tsx
@@ -46,7 +46,7 @@ export const AssetDataListItemStructure: React.FC<IAssetDataListItemStructurePro
 
     return (
         <DataList.Item
-            className={classNames('flex items-center justify-between gap-x-3 py-3 md:py-5', className)}
+            className={classNames('flex items-center justify-between gap-x-3 py-3 md:gap-x-4 md:py-5', className)}
             {...otherProps}
         >
             <div className="flex min-w-0 items-center gap-3">


### PR DESCRIPTION
## Description

Fixes spacing and sizing issues in asset-related components:

- **`DataListFilter`**: The search `AvatarIcon` and loading `Spinner` now use responsive sizing (`sm`/`md` on mobile, `md`/`lg` on desktop) so the filter input renders at the correct size on smaller viewports.
- **`AssetDataListItemStructure`**: Adds `md:gap-x-4` so the horizontal spacing between elements matches the design at desktop breakpoints.
- **Storybook**: Adds a `Loading` story for `DataListFilter` to cover the spinner state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] Made the corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project