### PR TITLE
fix(APP-789): Keep the decoded view active when editing a proposal action parameter whose calldata is temporarily empty

### DIFF
--- a/.changeset/fix-decoded-view-edit-resets-to-raw.md
+++ b/.changeset/fix-decoded-view-edit-resets-to-raw.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Keep the decoded view active when editing a proposal action parameter whose calldata is temporarily empty

--- a/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.test.tsx
@@ -419,4 +419,51 @@ describe('<ProposalActionsItem /> component', () => {
         expect(screen.getByTestId('decoder-mock').dataset.view).toEqual(ProposalActionsDecoderView.RAW);
         expect(screen.getByTestId('decoder-mock').dataset.mode).toEqual(ProposalActionsDecoderMode.WATCH);
     });
+
+    it('keeps the decoded view for a parameterised payable call whose calldata is 0x while editing', () => {
+        // Editing a parameter to an invalid/empty value makes the re-encode fall back to '0x'. Even when the call is
+        // payable (value > 0), the presence of parameters must prevent it being reclassified as a native transfer and
+        // bounced to the raw view.
+        const params = [{ name: 'amount', type: 'uint', value: null }];
+        const action = generateProposalAction({
+            data: '0x',
+            value: '1000000000000000000',
+            inputData: { contract: 'Token', function: 'transfer', parameters: params },
+        });
+        isActionSupportedSpy.mockReturnValue(false);
+        render(createTestComponent({ action, editMode: true }));
+        const actionDecoder = screen.getByTestId('decoder-mock');
+        expect(actionDecoder.dataset.view).toEqual(ProposalActionsDecoderView.DECODED);
+        expect(actionDecoder.dataset.mode).toEqual(ProposalActionsDecoderMode.EDIT);
+    });
+
+    it('keeps the decoded view for a parameter-less write function with 0x calldata that sends no value', () => {
+        // A parameter-less write function (no value) must keep the decoded "no params" view so the data field can be
+        // pre-populated with the function selector. It must not be confused with a native transfer.
+        const action = generateProposalAction({
+            data: '0x',
+            value: '0',
+            inputData: { contract: 'Token', function: 'pause', parameters: [] },
+        });
+        isActionSupportedSpy.mockReturnValue(false);
+        render(createTestComponent({ action, editMode: true }));
+        const actionDecoder = screen.getByTestId('decoder-mock');
+        expect(actionDecoder.dataset.view).toEqual(ProposalActionsDecoderView.DECODED);
+        expect(actionDecoder.dataset.mode).toEqual(ProposalActionsDecoderMode.EDIT);
+    });
+
+    it('keeps the decoded view disabled for a native transfer carrying input-data with a function name', () => {
+        // A native transfer can carry input-data with a non-empty function name (e.g. "NativeTransfer") but no
+        // parameters and a non-zero value. It is still a native transfer, so the decoded view stays disabled.
+        const action = generateProposalAction({
+            data: '0x',
+            value: '10000000000000',
+            inputData: { contract: 'Wallet Address', function: 'NativeTransfer', parameters: [] },
+        });
+        isActionSupportedSpy.mockReturnValue(false);
+        render(createTestComponent({ action, editMode: true }));
+        const actionDecoder = screen.getByTestId('decoder-mock');
+        expect(actionDecoder.dataset.view).toEqual(ProposalActionsDecoderView.RAW);
+        expect(actionDecoder.dataset.mode).toEqual(ProposalActionsDecoderMode.EDIT);
+    });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
@@ -91,7 +91,22 @@ export const ProposalActionsItem = <TAction extends IProposalAction = IProposalA
     // - Native transfer: basic view available; decoded view disabled; raw view in watch mode
     const isAbiAvailable = action.inputData != null;
     const isRawCalldataAction = action.type === (ProposalActionTypeNoBasicView.RAW_CALLDATA as string);
-    const isNativeTransfer = action.data === '0x';
+
+    // A native transfer sends value with empty calldata ('0x') and has no parameters to decode. It must be detected
+    // from these intrinsic transaction properties, not from the encoded `data` alone: while editing a parameter in the
+    // decoded view an invalid/empty value transiently re-encodes the calldata to '0x', and keying off that would
+    // misclassify a parameterised call as a native transfer — disabling the decoded view and bouncing the user to raw.
+    // The "no parameters" term keeps the decoded view stable while editing a parameterised (incl. payable) call; the
+    // "sends value" term keeps the decoded "no params" view for parameter-less write functions, which send no value.
+    const isSendingValue = (() => {
+        try {
+            const normalizedValue = action.value.trim();
+            return normalizedValue !== '' && BigInt(normalizedValue) > BigInt(0);
+        } catch {
+            return false;
+        }
+    })();
+    const isNativeTransfer = action.data === '0x' && isSendingValue && !action.inputData?.parameters.length;
     const supportsDecodedView = isAbiAvailable && !isRawCalldataAction && !isNativeTransfer;
 
     const [activeViewMode, setActiveViewMode] = useState<ProposalActionsItemViewMode>(


### PR DESCRIPTION
## Description

When a user edits a proposal action parameter in the decoded view, the calldata can temporarily become empty or invalid during typing. This caused the component to reset back to the raw view, losing the user's context. This fix preserves the decoded view state even when the calldata is temporarily empty.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [ ] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project