### PR TITLE
feat: Add addressUtils.truncateHash for 32-byte hashes

### DIFF
--- a/.changeset/truncate-hash-util.md
+++ b/.changeset/truncate-hash-util.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": minor
+---
+
+Add `addressUtils.truncateHash` for truncating 32-byte hashes (merkle roots, transaction/block hashes)

--- a/src/modules/utils/addressUtils/addressUtils.test.tsx
+++ b/src/modules/utils/addressUtils/addressUtils.test.tsx
@@ -47,6 +47,23 @@ describe('address utils', () => {
         });
     });
 
+    describe('truncateHash', () => {
+        it('returns empty string when hash is not defined', () => {
+            expect(addressUtils.truncateHash()).toEqual('');
+        });
+
+        it('returns input string when input is not a valid 32-byte hash', () => {
+            const value = '0xe11bfcbdd43745d4aa6f4f18e24ad24f4623af04';
+            expect(addressUtils.truncateHash(value)).toEqual(value);
+        });
+
+        it('correctly truncates the hash', () => {
+            const value = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+            const expectedValue = '0x12345678…90abcdef';
+            expect(addressUtils.truncateHash(value)).toEqual(expectedValue);
+        });
+    });
+
     describe('getChecksum', () => {
         it('returns the address on its checksum format', () => {
             const value = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';

--- a/src/modules/utils/addressUtils/addressUtils.ts
+++ b/src/modules/utils/addressUtils/addressUtils.ts
@@ -1,4 +1,4 @@
-import { type Address, getAddress, isAddress } from 'viem';
+import { type Address, getAddress, isAddress, isHash } from 'viem';
 
 export interface IIsAddressParams {
     /**
@@ -22,10 +22,17 @@ class AddressUtils {
      * @param address The address to truncate
      * @returns The truncated address when the address input is valid, the address input as is otherwise.
      */
-    truncateAddress = (address = ''): string =>
-        this.isAddress(address)
-            ? `${address.slice(0, 6)}…${address.slice(address.length - 4, address.length)}`
-            : address;
+    truncateAddress = (address = ''): string => (this.isAddress(address) ? this.truncate(address, 6, 4) : address);
+
+    /**
+     * Truncates the input hash (e.g. a merkle root, transaction or block hash) by displaying the first 10 and last 8 characters.
+     * @param hash The 32-byte hash to truncate
+     * @returns The truncated hash when the input is a valid 32-byte hash, the input as is otherwise.
+     */
+    truncateHash = (hash = ''): string => (isHash(hash) ? this.truncate(hash, 10, 8) : hash);
+
+    private truncate = (value: string, start: number, end: number): string =>
+        `${value.slice(0, start)}…${value.slice(value.length - end, value.length)}`;
 
     /**
      * Returns the address on its checksum format


### PR DESCRIPTION
## Description

Adds `addressUtils.truncateHash` for truncating 32-byte hashes (merkle roots, transaction/block hashes) to a `0x12345678…90abcdef` display format. Validation uses viem's `isHash` (no re-export — consumed internally), and a shared private `truncate(value, start, end)` core now backs both `truncateAddress` and `truncateHash` so the separator/format stay unified.

Motivated by app-next, where `addressUtils.truncateAddress` was being reached for to shorten a `merkleRoot` but silently no-ops on non-addresses (it only truncates valid 20-byte addresses). This gives consumers the correct primitive instead of inlining bespoke slice logic.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation <!-- JSDoc on the new method; modules/utils has no .mdx/stories convention (matches ensUtils sibling) -->
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project