### PR TITLE
fix: keep SVG viewBox so icons scale instead of clipping

### DIFF
--- a/.changeset/keep-svg-viewbox.md
+++ b/.changeset/keep-svg-viewbox.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Keep the `viewBox` on bundled SVG icons so they scale correctly when rendered below their intrinsic 16px size (e.g. `size-3` in small buttons) instead of being clipped.

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,19 @@ export default [
                 ],
             }),
             images({ include: ['**/*.png', '**/*.jpg'] }),
-            svgr(),
+            svgr({
+                // Keep the viewBox so icons scale instead of getting clipped when
+                // rendered at a size other than their intrinsic 16px (e.g. size-3 in
+                // small buttons). SVGO's preset-default removes it by default.
+                svgoConfig: {
+                    plugins: [
+                        {
+                            name: 'preset-default',
+                            params: { overrides: { removeViewBox: false } },
+                        },
+                    ],
+                },
+            }),
             terser(),
         ],
     },


### PR DESCRIPTION
## Problem

Icons rendered below their intrinsic 16px get **clipped** instead of scaling down. Most visible on the `PEN` icon in small (`size="sm"`) buttons — the pencil is drawn edge-to-edge (viewBox `0 0 16 16`), so its tip is cropped when the SVG viewport shrinks to `size-3` (12px).

Rendered output today (note the missing `viewBox`):

```html
<svg width="16" height="16" class="... size-3 ...">  <!-- no viewBox -->
```

## Root cause

`@svgr/rollup` runs SVGO's `preset-default`, which includes `removeViewBox: true`. Because our source SVGs carry `width`/`height`, SVGO treats the viewBox as redundant and strips it. Without a viewBox there's no coordinate remapping, so a `size-3` (12px) box simply crops the 16-unit drawing rather than scaling it. Icons with internal padding crop only whitespace (unnoticed); edge-to-edge glyphs like `PEN` clip visibly.

This also explains why `size="md"` (16px = intrinsic) looked fine while `size="sm"` (12px) did not.

## Fix

Override `removeViewBox` in **`rollup.config.mjs`** (the published bundle) so the viewBox is preserved.

Verified after rebuild: the `PEN` component now emits `viewBox="0 0 16 16"` and scales cleanly at 12px. Fixes **all** icons at non-16px sizes, not just `PEN`.

## Why Storybook needs no change

Storybook uses `vite-plugin-svgr`, which calls `@svgr/core` with `caller.defaultPlugins: [jsx]` — the SVGO plugin is **not** in the plugin list, so SVGO never runs there and the viewBox is already preserved. Verified empirically: transforming an SVG through the Storybook path keeps the viewBox with no config. (Adding an `svgoConfig` without an explicit `plugins: ["@svgr/plugin-svgo", "@svgr/plugin-jsx"]` array would be a no-op anyway.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)